### PR TITLE
Feature: Add attribute update notifier

### DIFF
--- a/components/esp_matter/esp_matter_attribute_utils.h
+++ b/components/esp_matter/esp_matter_attribute_utils.h
@@ -236,6 +236,21 @@ esp_err_t set_callback(callback_t callback);
  */
 esp_err_t update(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *val);
 
+/** Notify attribute update
+ *
+ * This API notifies the that the attribute value has been changed.
+ * When the subscriber checks for a new value, the application will read the value from the database and
+ * then it will report the value to the subscriber.
+ *
+ * @param[in] endpoint_id Endpoint ID of the attribute.
+ * @param[in] cluster_id Cluster ID of the attribute.
+ * @param[in] attribute_id Attribute ID of the attribute.
+ *
+ * @return ESP_OK on success.
+ * @return error in case of failure.
+ */
+esp_err_t notify_update(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id);
+
 /** Attribute value print
  *
  * This API prints the attribute value according to the type.


### PR DESCRIPTION
As I commented at https://github.com/espressif/esp-matter/issues/28#issuecomment-1211038474, this is a way to notify that the attribute has changed, but avoiding `attribute:update`, because changing the attribute value when its managed externally might result in an undesired behavior.

Use case of this can be devices that takes a noticiable amount of time to go from one state to another, so that when the state is set, it will get different states before reaching the target state, so changing through `attribute:update` would change the target state.
(Specific examples can be window shade and barrier positions, which according to the ZCL specification, the **current** position must be reported)