### PR TITLE
Multiple window_covering fixes

### DIFF
--- a/components/esp_matter/esp_matter_cluster.cpp
+++ b/components/esp_matter/esp_matter_cluster.cpp
@@ -1382,7 +1382,7 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
             global::attribute::create_cluster_revision(cluster, config->cluster_revision);
             attribute::create_type(cluster, config->type);
             attribute::create_config_status(cluster, config->config_status);
-            attribute::create_operational_status(cluster, config->config_status);
+            attribute::create_operational_status(cluster, config->operational_status);
             attribute::create_end_product_type(cluster, config->end_product_type);
             attribute::create_mode(cluster, config->mode);
         } else {

--- a/components/esp_matter/esp_matter_cluster.h
+++ b/components/esp_matter/esp_matter_cluster.h
@@ -341,7 +341,7 @@ typedef struct config {
     uint16_t installed_closed_limit_tilt;
     uint16_t mode;
     uint16_t safety_status;
-    config() : cluster_revision(6), type(0), operational_status(0), end_product_type(0), mode(0) {}
+    config() : cluster_revision(5), type(0), operational_status(0), end_product_type(0), mode(0) {}
 } config_t;
 
 cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags);

--- a/components/esp_matter/esp_matter_feature.cpp
+++ b/components/esp_matter/esp_matter_feature.cpp
@@ -473,7 +473,7 @@ esp_err_t add(cluster_t *cluster, config_t *config)
         attribute::create_installed_open_limit_lift(cluster, config->installed_open_limit_lift);
         attribute::create_installed_closed_limit_lift(cluster, config->installed_closed_limit_lift);
     } else {
-        ESP_LOGI(TAG, "Lift related attributes were not created because cluster does not support Position_Aware_Lift feature");
+        ESP_LOGW(TAG, "Lift related attributes were not created because cluster does not support Position_Aware_Lift feature");
     }
 
     if((get_feature_map_value(cluster) & abs_and_pa_tl_and_tl_feature_map) == abs_and_pa_tl_and_tl_feature_map) {
@@ -482,19 +482,19 @@ esp_err_t add(cluster_t *cluster, config_t *config)
         attribute::create_installed_open_limit_tilt(cluster, config->installed_open_limit_tilt);
         attribute::create_installed_closed_limit_tilt(cluster, config->installed_closed_limit_tilt);
     } else {
-        ESP_LOGI(TAG, "Tilt related attributes were not created because cluster does not support Position_Aware_Tilt feature");
+        ESP_LOGW(TAG, "Tilt related attributes were not created because cluster does not support Position_Aware_Tilt feature");
     }
 
     if((get_feature_map_value(cluster) & abs_and_lift_feature_map) == abs_and_lift_feature_map) {
 	    command::create_go_to_lift_value(cluster);
     } else {
-        ESP_LOGI(TAG, "Lift commands were not created because cluster does not support Lift feature");
+        ESP_LOGW(TAG, "Lift commands were not created because cluster does not support Lift feature");
     }
 
     if((get_feature_map_value(cluster) & abs_and_tilt_feature_map) == abs_and_tilt_feature_map) {
         command::create_go_to_tilt_value(cluster);
     } else {
-        ESP_LOGI(TAG, "Tilt commands were not created because cluster does not support Tilt feature");
+        ESP_LOGW(TAG, "Tilt commands were not created because cluster does not support Tilt feature");
     }
 
     return ESP_OK;

--- a/components/esp_matter/esp_matter_feature.cpp
+++ b/components/esp_matter/esp_matter_feature.cpp
@@ -480,7 +480,7 @@ esp_err_t add(cluster_t *cluster, config_t *config)
         attribute::create_physical_closed_limit_tilt(cluster, config->physical_closed_limit_tilt);
         attribute::create_current_position_tilt(cluster, config->current_position_tilt);
         attribute::create_installed_open_limit_tilt(cluster, config->installed_open_limit_tilt);
-        attribute::create_installed_closed_limit_tilt(cluster, config->installed_closed_limit_lift);
+        attribute::create_installed_closed_limit_tilt(cluster, config->installed_closed_limit_tilt);
     } else {
         ESP_LOGI(TAG, "Tilt related attributes were not created because cluster does not support Position_Aware_Tilt feature");
     }


### PR DESCRIPTION
When adding `absolute_position` feature and previously added `lift` and `position_aware_lift` **or** `tilt` and `position_aware_tilt`, neither attributes and commands are created. 
Following the Matter specification, should be expected the following attributes and commands

- If I enable `lift`, `position_aware_lift`, `tilt` and `position_aware_tilt`:
  - Attributes:
    - `physical_closed_limit_lift`
    - `current_position_lift`
    - `installed_open_limit_lift`
    - `installed_closed_limit_lift`
    - `physical_closed_limit_tilt`
    - `current_position_tilt`
    - `installed_open_limit_tilt`
    - `installed_closed_limit_tilt`
  - Commands:
    - `go_to_lift_value`
    - `go_to_tilt_value`
- If I enable `lift` and `position_aware_lift` only:
  - Attributes:
    - `physical_closed_limit_lift`
    - `current_position_lift`
    - `installed_open_limit_lift`
    - `installed_closed_limit_lift`
  - Commands:
    - `go_to_lift_value`
- If I enable `tilt` and `position_aware_tilt` only:
  - Attributes:
    - `physical_closed_limit_tilt`
    - `current_position_tilt`
    - `installed_open_limit_tilt`
    - `installed_closed_limit_tilt`
  - Commands:
    - `go_to_tilt_value`
- If I enable `lift` only:
  - Attributes:
    - none
  - Commands:
    - `go_to_lift_value`
- If I enable `tilt` only:
  - Attributes:
    - none
  - Commands:
    - `go_to_tilt_value`

In this pull request I have included a fix where instead of returning with `ESP_ERR_NOT_SUPPORTED` if all the features are not added previously (which is the current behavior), it only returns `ESP_ERR_NOT_SUPPORTED` if none of the features mentioned have been added previously. If at least one is supported, it will create the expected attributes & commands. 
(Fix #120)
~Also performed some formatting at `esp_matter_feature.cpp` at the window_covering namespace~, No longer necessary after some change made in main branch.


I also have found other problems related to window covering cluster:
- The cluster revision for window covering is 6, but the highest cluster revisión for window covering cluster at the Matter 1.0 specifications is 5.

- When a window covering cluster is created `operational_status` it is ignored and the value of `config_status` is set instead.