### PR TITLE
Added the events related to Fabric and called OpenBasicCommissioningW…

### DIFF
--- a/components/esp_matter/esp_matter.h
+++ b/components/esp_matter/esp_matter.h
@@ -122,6 +122,10 @@ enum
     kCommissioningWindowOpened,
     /** Signals that Commissioning window is now closed  */
     kCommissioningWindowClosed,
+    kFabricWillBeRemoved,
+    kFabricRemoved,
+    kFabricCommitted,
+    kFabricUpdated,
 };
 
 } // DeviceEventType

--- a/components/esp_matter/esp_matter_event.cpp
+++ b/components/esp_matter/esp_matter_event.cpp
@@ -18,7 +18,6 @@
 #include <app/clusters/switch-server/switch-server.h>
 #include <platform/DeviceControlServer.h>
 
-static const char *TAG = "esp_matter_event";
 
 using chip::DeviceLayer::DeviceControlServer;
 using chip::EndpointId;

--- a/examples/light/main/app_main.cpp
+++ b/examples/light/main/app_main.cpp
@@ -24,7 +24,6 @@ using namespace esp_matter;
 using namespace esp_matter::attribute;
 using namespace esp_matter::endpoint;
 using namespace chip::app::Clusters;
-
 static void app_event_cb(const ChipDeviceEvent *event, intptr_t arg)
 {
     switch (event->Type) {
@@ -56,6 +55,21 @@ static void app_event_cb(const ChipDeviceEvent *event, intptr_t arg)
         ESP_LOGI(TAG, "Commissioning window closed");
         break;
 
+    case chip::DeviceLayer::DeviceEventType::kFabricRemoved:
+        ESP_LOGI(TAG, "Fabric Removed Successfully");
+        break;
+
+    case chip::DeviceLayer::DeviceEventType::kFabricWillBeRemoved:
+        ESP_LOGI(TAG, "Fabric Will Be Removed");
+        break;
+
+    case chip::DeviceLayer::DeviceEventType::kFabricUpdated:
+        ESP_LOGI(TAG, "Fabric is updated");
+        break;
+
+    case chip::DeviceLayer::DeviceEventType::kFabricCommitted:
+        ESP_LOGI(TAG, "Fabric is committed");
+        break;
     default:
         break;
     }
@@ -128,7 +142,6 @@ extern "C" void app_main()
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Matter start failed: %d", err);
     }
-
     /* Starting driver with default values */
     app_driver_light_set_defaults(light_endpoint_id);
 


### PR DESCRIPTION
Added the events related to Fabric in esp_matter_core.cpp.
Called the OpenBasicCommissioningWindow api from OnFabricRemoved in esp_matter_core.cpp.
Added the fabric related events in the light example.
The commissioning window opens as the OnFabricRemoved is triggered.
On-network commissioning takes place successfully after the commissioning window is opened.