### PR TITLE
Handled the events related to Fabric in esp_matter_core.cpp and calle… (CON-256)

### DIFF
--- a/components/esp_matter/esp_matter.h
+++ b/components/esp_matter/esp_matter.h
@@ -120,8 +120,18 @@ enum
     kCommissioningSessionStopped,
     /** Signals that Commissioning window is now opend */
     kCommissioningWindowOpened,
-    /** Signals that Commissioning window is now closed  */
+    /** Signals that Commissioning window is now closed */
     kCommissioningWindowClosed,
+    /** Signals that a fabric is about to be deleted. This allows actions to be taken that need the
+    fabric to still be around before we delete it */
+    kFabricWillBeRemoved,
+    /** Signals that a fabric is deleted */
+    kFabricRemoved,
+    /** Signals that a fabric in Fabric Table is persisted to storage, by CommitPendingFabricData */
+    kFabricCommitted,
+    /** Signals that operational credentials are changed, which may not be persistent.
+    Can be used to affect what is needed for UpdateNOC prior to commit */
+    kFabricUpdated,
 };
 
 } // DeviceEventType


### PR DESCRIPTION
Handled the events related to Fabric in esp_matter_core.cpp.
Called the OpenBasicCommissioningWindow api from OnFabricRemoved in the light example.
Added the fabric related events in the light example.
The Commissioning window opens when OnFabricRemoved is triggered in the case of light example.
The OnNetworkCommissioning is successful when the commissioning window is opened.