### PR TITLE
Added the support to pass the private data in esp_matter_start. (CON-316)

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,10 @@
+# 15-March-2023
+ 
+API Change
+
+esp_matter::start(event_callback_t callback, intptr_t callback_arg = static_cast<intptr_t>(NULL))
+- This API now accepts a parameter to pass additional data to the event callback. By default, the data is set to NULL in the API.
+
 # 14-June-2022
 
 First Github release of ESP Matter

--- a/components/esp_matter/esp_matter_core.cpp
+++ b/components/esp_matter/esp_matter_core.cpp
@@ -897,7 +897,7 @@ static void device_callback_internal(const ChipDeviceEvent * event, intptr_t arg
     }
 }
 
-static esp_err_t chip_init(event_callback_t callback)
+static esp_err_t chip_init(event_callback_t callback, intptr_t callback_arg)
 {
     if (chip::Platform::MemoryInit() != CHIP_NO_ERROR) {
         ESP_LOGE(TAG, "Failed to initialize CHIP memory pool");
@@ -929,7 +929,7 @@ static esp_err_t chip_init(event_callback_t callback)
     }
     PlatformMgr().AddEventHandler(device_callback_internal, static_cast<intptr_t>(NULL));
     if(callback) {
-       PlatformMgr().AddEventHandler(callback, static_cast<intptr_t>(NULL));
+       PlatformMgr().AddEventHandler(callback, callback_arg);
     }
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     if (ThreadStackMgr().InitThreadStack() != CHIP_NO_ERROR) {
@@ -949,7 +949,7 @@ static esp_err_t chip_init(event_callback_t callback)
     return ESP_OK;
 }
 
-esp_err_t start(event_callback_t callback)
+esp_err_t start(event_callback_t callback, intptr_t callback_arg)
 {
     if (esp_matter_started) {
         ESP_LOGE(TAG, "esp_matter has started");
@@ -957,7 +957,7 @@ esp_err_t start(event_callback_t callback)
     }
     esp_matter_ota_requestor_init();
 
-    esp_err_t err = chip_init(callback);
+    esp_err_t err = chip_init(callback, callback_arg);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Error initializing matter");
         return err;

--- a/components/esp_matter/esp_matter_core.h
+++ b/components/esp_matter/esp_matter_core.h
@@ -52,11 +52,12 @@ typedef void (*event_callback_t)(const ChipDeviceEvent *event, intptr_t arg);
  * Initialize and start the matter thread.
  *
  * @param[in] callback event callback.
+ * @param[in] callback_arg private data to pass to callback function, optional argument, by default set to NULL.
  *
  * @return ESP_OK on success.
  * @return error in case of failure.
  */
-esp_err_t start(event_callback_t callback);
+esp_err_t start(event_callback_t callback, intptr_t callback_arg = static_cast<intptr_t>(NULL));
 
 /** Factory reset
  *


### PR DESCRIPTION

**Problem:**
#240 

**Change Overview:**
Previously , esp_matter::start() internally used NULL for the private data.
Made the provision to pass the private data in esp_matter::start.

**Tests**
Successfully tested for the private data by passing it in esp_matter::start.




