### PR TITLE
[blemesh & zigbee bridge] Adds support to reduce complexity of bridged_device search using priv_data instead of using endpoint (CON-343)

### DIFF
--- a/components/esp_matter/esp_matter_command.cpp
+++ b/components/esp_matter/esp_matter_command.cpp
@@ -39,7 +39,7 @@ void DispatchSingleClusterCommandCommon(const ConcreteCommandPath &command_path,
     uint16_t endpoint_id = command_path.mEndpointId;
     uint32_t cluster_id = command_path.mClusterId;
     uint32_t command_id = command_path.mCommandId;
-    ESP_LOGI(TAG, "Received command 0x%04X for enpoint 0x%04X's cluster 0x%08X", command_id, endpoint_id, cluster_id);
+    ESP_LOGI(TAG, "Received command 0x%08X for endpoint 0x%04X's cluster 0x%08X", command_id, endpoint_id, cluster_id);
 
     node_t *node = node::get();
     endpoint_t *endpoint = endpoint::get(node, endpoint_id);

--- a/components/esp_matter_bridge/esp_matter_bridge.cpp
+++ b/components/esp_matter_bridge/esp_matter_bridge.cpp
@@ -242,7 +242,7 @@ static bool parent_endpoint_is_valid(node_t *node, uint16_t parent_endpoint_id)
     return false;
 }
 
-device_t *create_device(node_t *node, uint16_t parent_endpoint_id, uint32_t device_type_id)
+device_t *create_device(node_t *node, uint16_t parent_endpoint_id, uint32_t device_type_id, void *priv_data)
 {
     // Check whether the parent endpoint is valid
     if (!parent_endpoint_is_valid(node, parent_endpoint_id)) {
@@ -256,7 +256,7 @@ device_t *create_device(node_t *node, uint16_t parent_endpoint_id, uint32_t devi
     dev->persistent_info.parent_endpoint_id = parent_endpoint_id;
     bridged_node::config_t bridged_node_config;
     dev->endpoint =
-        bridged_node::create(node, &bridged_node_config, ENDPOINT_FLAG_DESTROYABLE | ENDPOINT_FLAG_BRIDGE, NULL);
+        bridged_node::create(node, &bridged_node_config, ENDPOINT_FLAG_DESTROYABLE | ENDPOINT_FLAG_BRIDGE, priv_data);
     if (!(dev->endpoint)) {
         ESP_LOGE(TAG, "Could not create esp_matter endpoint for bridged device");
         free(dev);
@@ -300,7 +300,7 @@ device_t *create_device(node_t *node, uint16_t parent_endpoint_id, uint32_t devi
     return dev;
 }
 
-device_t *resume_device(node_t *node, uint16_t device_endpoint_id)
+device_t *resume_device(node_t *node, uint16_t device_endpoint_id, void *priv_data)
 {
     esp_err_t err = ESP_OK;
     device_persistent_info_t persistent_info;
@@ -318,7 +318,7 @@ device_t *resume_device(node_t *node, uint16_t device_endpoint_id)
     dev->persistent_info = persistent_info;
     bridged_node::config_t bridged_node_config;
     dev->endpoint = bridged_node::resume(node, &bridged_node_config, ENDPOINT_FLAG_DESTROYABLE | ENDPOINT_FLAG_BRIDGE,
-                                         device_endpoint_id, NULL);
+                                         device_endpoint_id, priv_data);
     if (!(dev->endpoint)) {
         ESP_LOGE(TAG, "Could not resume esp_matter endpoint for bridged device");
         free(dev);

--- a/components/esp_matter_bridge/esp_matter_bridge.h
+++ b/components/esp_matter_bridge/esp_matter_bridge.h
@@ -40,9 +40,9 @@ esp_err_t get_bridged_endpoint_ids(uint16_t *matter_endpoint_id_array);
 
 esp_err_t erase_bridged_device_info(uint16_t matter_endpoint_id);
 
-device_t *create_device(esp_matter::node_t *node, uint16_t parent_endpoint_id, uint32_t device_type_id);
+device_t *create_device(esp_matter::node_t *node, uint16_t parent_endpoint_id, uint32_t device_type_id, void *priv_data);
 
-device_t *resume_device(esp_matter::node_t *node, uint16_t device_endpoint_id);
+device_t *resume_device(esp_matter::node_t *node, uint16_t device_endpoint_id, void *priv_data);
 
 esp_err_t set_device_type(device_t *bridged_device, uint32_t device_type_id);
 

--- a/examples/blemesh_bridge/main/app_main.cpp
+++ b/examples/blemesh_bridge/main/app_main.cpp
@@ -66,9 +66,8 @@ static esp_err_t app_attribute_update_cb(callback_type_t type, uint16_t endpoint
                                          uint32_t attribute_id, esp_matter_attr_val_t *val, void *priv_data)
 {
     esp_err_t err = ESP_OK;
-
     if (type == PRE_UPDATE) {
-        err = blemesh_bridge_attribute_update(endpoint_id, cluster_id, attribute_id, val);
+        err = blemesh_bridge_attribute_update(endpoint_id, cluster_id, attribute_id, val, (app_bridged_device_t *)priv_data);
     }
     return err;
 }

--- a/examples/blemesh_bridge/main/blemesh_bridge.cpp
+++ b/examples/blemesh_bridge/main/blemesh_bridge.cpp
@@ -14,9 +14,9 @@
 #include <esp_matter_core.h>
 #include <esp_matter_bridge.h>
 
+#include <app_bridged_device.h>
 #include <blemesh_bridge.h>
 #include <app_blemesh.h>
-#include <app_bridged_device.h>
 
 static const char *TAG = "blemesh_bridge";
 
@@ -69,9 +69,8 @@ esp_err_t blemesh_bridge_match_bridged_onoff_light(uint8_t *composition_data, ui
 }
 
 esp_err_t blemesh_bridge_attribute_update(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id,
-                                          esp_matter_attr_val_t *val)
+                                          esp_matter_attr_val_t *val, app_bridged_device_t *bridged_device)
 {
-    app_bridged_device_t *bridged_device = app_bridge_get_device_by_matter_endpointid(endpoint_id);
     if (bridged_device && bridged_device->dev && bridged_device->dev->endpoint) {
         if (cluster_id == OnOff::Id) {
             if (attribute_id == OnOff::Attributes::OnOff::Id) {
@@ -79,6 +78,9 @@ esp_err_t blemesh_bridge_attribute_update(uint16_t endpoint_id, uint32_t cluster
                 app_ble_mesh_onoff_set(bridged_device->dev_addr.blemesh_addr, val->val.b);
             }
         }
+    }
+    else{
+        ESP_LOGE(TAG, "Unable to Update Bridge Device, ep: %d, cluster: %d, att: %d", endpoint_id, cluster_id, attribute_id);
     }
     return ESP_OK;
 }

--- a/examples/blemesh_bridge/main/blemesh_bridge.h
+++ b/examples/blemesh_bridge/main/blemesh_bridge.h
@@ -18,6 +18,7 @@ extern "C" {
 #include <esp_log.h>
 
 #include <esp_matter_attribute_utils.h>
+#include <app_bridged_device.h>
 
 /**
  * @brief
@@ -30,7 +31,7 @@ extern "C" {
  * @return esp_err_t
  */
 esp_err_t blemesh_bridge_attribute_update(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id,
-                                          esp_matter_attr_val_t *val);
+                                          esp_matter_attr_val_t *val, app_bridged_device_t *bridged_device);
 
 #ifdef __cplusplus
 }

--- a/examples/common/app_bridge/app_bridged_device.cpp
+++ b/examples/common/app_bridge/app_bridged_device.cpp
@@ -126,7 +126,7 @@ app_bridged_device_t *app_bridge_create_bridged_device(node_t *node, uint16_t pa
         return NULL;
     }
     app_bridged_device_t *new_dev = (app_bridged_device_t *)calloc(1, sizeof(app_bridged_device_t));
-    new_dev->dev = esp_matter_bridge::create_device(node, parent_endpoint_id, matter_device_type_id);
+    new_dev->dev = esp_matter_bridge::create_device(node, parent_endpoint_id, matter_device_type_id, new_dev);
     if (!(new_dev->dev)) {
         ESP_LOGE(TAG, "Failed to create the bridged device");
         free(new_dev);
@@ -175,7 +175,7 @@ esp_err_t app_bridge_initialize(node_t *node)
                 ESP_LOGE(TAG, "Failed to alloc memory for the resumed bridged device");
                 continue;
             }
-            new_dev->dev = esp_matter_bridge::resume_device(node, matter_endpoint_id_array[idx]);
+            new_dev->dev = esp_matter_bridge::resume_device(node, matter_endpoint_id_array[idx], new_dev);
             if (!(new_dev->dev)) {
                 ESP_LOGE(TAG, "Failed to resume the bridged device");
                 free(new_dev);
@@ -230,18 +230,6 @@ esp_err_t app_bridge_remove_device(app_bridged_device_t *bridged_device)
 }
 
 /** ZigBee Device APIs */
-app_bridged_device_t *app_bridge_get_device_by_matter_endpointid(uint16_t matter_endpointid)
-{
-    app_bridged_device_t *current_dev = g_bridged_device_list;
-    while (current_dev) {
-        if (current_dev->dev && (esp_matter::endpoint::get_id(current_dev->dev->endpoint) == matter_endpointid)) {
-            return current_dev;
-        }
-        current_dev = current_dev->next;
-    }
-    return NULL;
-}
-
 app_bridged_device_t *app_bridge_get_device_by_zigbee_shortaddr(uint16_t zigbee_shortaddr)
 {
     app_bridged_device_t *current_dev = g_bridged_device_list;

--- a/examples/common/app_bridge/app_bridged_device.h
+++ b/examples/common/app_bridge/app_bridged_device.h
@@ -67,8 +67,6 @@ esp_err_t app_bridge_initialize(node_t *node);
 
 esp_err_t app_bridge_remove_device(app_bridged_device_t *bridged_device);
 
-app_bridged_device_t *app_bridge_get_device_by_matter_endpointid(uint16_t matter_endpointid);
-
 /** ZigBee Device APIs */
 app_bridged_device_t *app_bridge_get_device_by_zigbee_shortaddr(uint16_t zigbee_shortaddr);
 

--- a/examples/zigbee_bridge/main/app_main.cpp
+++ b/examples/zigbee_bridge/main/app_main.cpp
@@ -67,7 +67,7 @@ static esp_err_t app_attribute_update_cb(callback_type_t type, uint16_t endpoint
     esp_err_t err = ESP_OK;
 
     if (type == PRE_UPDATE) {
-        err = zigbee_bridge_attribute_update(endpoint_id, cluster_id, attribute_id, val);
+        err = zigbee_bridge_attribute_update(endpoint_id, cluster_id, attribute_id, val, (app_bridged_device_t *)priv_data);
     }
     return err;
 }

--- a/examples/zigbee_bridge/main/zigbee_bridge.cpp
+++ b/examples/zigbee_bridge/main/zigbee_bridge.cpp
@@ -50,9 +50,8 @@ void zigbee_bridge_find_bridged_on_off_light_cb(zb_uint8_t zdo_status, zb_uint16
 }
 
 esp_err_t zigbee_bridge_attribute_update(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id,
-                                         esp_matter_attr_val_t *val)
+                                         esp_matter_attr_val_t *val, app_bridged_device_t *zigbee_device)
 {
-    app_bridged_device_t *zigbee_device = app_bridge_get_device_by_matter_endpointid(endpoint_id);
     if (zigbee_device && zigbee_device->dev && zigbee_device->dev->endpoint) {
         if (cluster_id == OnOff::Id) {
             if (attribute_id == OnOff::Attributes::OnOff::Id) {
@@ -67,6 +66,9 @@ esp_err_t zigbee_bridge_attribute_update(uint16_t endpoint_id, uint32_t cluster_
                 esp_zb_zcl_on_off_cmd_req(&cmd_req);
             }
         }
+    }
+    else{
+        ESP_LOGE(TAG, "Unable to Update Bridge Device, ep: %d, cluster: %d, att: %d", endpoint_id, cluster_id, attribute_id);
     }
     return ESP_OK;
 }

--- a/examples/zigbee_bridge/main/zigbee_bridge.h
+++ b/examples/zigbee_bridge/main/zigbee_bridge.h
@@ -11,9 +11,10 @@
 #include <esp_matter_attribute_utils.h>
 #include <esp_zigbee_api_HA_standard.h>
 #include <esp_zigbee_api_core.h>
+#include <app_bridged_device.h>
 #include <stdint.h>
 
 void zigbee_bridge_find_bridged_on_off_light_cb(zb_uint8_t zdo_status, zb_uint16_t addr, zb_uint8_t endpoint);
 
 esp_err_t zigbee_bridge_attribute_update(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id,
-                                         esp_matter_attr_val_t *val);
+                                         esp_matter_attr_val_t *val, app_bridged_device_t *zigbee_device);


### PR DESCRIPTION
Problem:
- To reduce complexity of **blemesh_bridge** and **zigbee_bridge** code using a pointer of instead of searching the created `bridged_device`'s based on `matter_endpoint_id`.

Change overview:
- Added `*priv_data` support during creation of the endpoint, device and resuming it.
- Eliminated usage of function [`app_bridged_device_t *app_bridge_get_device_by_matter_endpointid(uint16_t matter_endpointid)`](https://github.com/espressif/esp-matter/blob/main/examples/common/app_bridge/app_bridged_device.cpp#LL233-L243).
- Fixes issue #60 

Tests: 
- Successfully tested on [`blemesh_bridge`](https://github.com/espressif/esp-matter/tree/main/examples/blemesh_bridge) and [`zigbee_bridge`](https://github.com/espressif/esp-matter/tree/main/examples/zigbee_bridge) example.