### PR TITLE
Added constructors for cluster config structures with const members (CON-389)

### DIFF
--- a/components/esp_matter/esp_matter_cluster.h
+++ b/components/esp_matter/esp_matter_cluster.h
@@ -325,7 +325,7 @@ typedef struct config {
     const uint8_t end_product_type;
     uint8_t mode;
     feature::lift::config_t lift;
-    config() : cluster_revision(5), type(0), config_status(0), operational_status(0), end_product_type(0), mode(0) {}
+    config(uint8_t end_product_type = 0) : cluster_revision(5), type(0), config_status(0), operational_status(0), end_product_type(end_product_type), mode(0) {}
 } config_t;
 
 cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags, uint32_t features);
@@ -447,7 +447,12 @@ typedef struct config {
     nullable<int16_t> capacity;
     // Pump Settings Attributes
     uint8_t operation_mode;
-    config() : cluster_revision(3), max_pressure(), max_speed(), max_flow(), effective_operation_mode(0), effective_control_mode(0), capacity(), operation_mode(0) {}
+    config(
+        nullable<int16_t> max_pressure = nullable<int16_t>(),
+        nullable<uint16_t> max_speed = nullable<uint16_t>(),
+        nullable<uint16_t> max_flow = nullable<uint16_t>()
+    ) : cluster_revision(3), max_pressure(max_pressure), max_speed(max_speed), max_flow(max_flow),
+        effective_operation_mode(0), effective_control_mode(0), capacity(), operation_mode(0) {}
 } config_t;
 
 cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags);

--- a/components/esp_matter/esp_matter_endpoint.h
+++ b/components/esp_matter/esp_matter_endpoint.h
@@ -304,6 +304,7 @@ typedef struct config {
     cluster::groups::config_t groups;
     cluster::scenes::config_t scenes;
     cluster::window_covering::config_t window_covering;
+    config(uint8_t end_product_type = 0) : window_covering(end_product_type) {}
 } config_t;
 
 uint32_t get_device_type_id();
@@ -389,6 +390,11 @@ typedef struct config {
     cluster::identify::config_t identify;
     cluster::on_off::config_t on_off;
     cluster::pump_configuration_and_control::config_t pump_configuration_and_control;
+    config(
+        nullable<int16_t> max_pressure = nullable<int16_t>(),
+        nullable<uint16_t> max_speed = nullable<uint16_t>(),
+        nullable<uint16_t> max_flow = nullable<uint16_t>()
+    ) : pump_configuration_and_control(max_pressure, max_speed, max_flow) {}
 } config_t;
 
 uint32_t get_device_type_id();

--- a/docs/en/developing.rst
+++ b/docs/en/developing.rst
@@ -625,6 +625,28 @@ creating in the *app_main.cpp* of the example. Examples:
       door_lock::config_t door_lock_config;
       endpoint_t *endpoint = door_lock::create(node, &door_lock_config, ENDPOINT_FLAG_NONE);
 
+-  window_covering_device:
+
+   ::
+
+      window_covering_device::config_t window_covering_device_config(static_cast<uint8_t>(chip::app::Clusters::WindowCovering::EndProductType::kTiltOnlyInteriorBlind));
+      endpoint_t *endpoint = window_covering_device::create(node, &window_covering_config, ENDPOINT_FLAG_NONE);
+
+   The ``window_covering_device`` ``config_t`` structure includes a constructor that allows specifying
+   an end product type different than the default one, which is "Roller shade".
+   Once a ``config_t`` instance has been instantiated, its end product type cannot be modified.
+
+- pump
+
+   ::
+
+      pump::config_t pump_config(1, 10, 20);
+      endpoint_t *endpoint = pump::create(node, &pump_config, ENDPOINT_FLAG_NONE);
+
+   The ``pump`` ``config_t`` structure includes a constructor that allows specifying
+   maximum pressure, maximum speed and maximum flow values. If they aren't set, they will be set to null by default.
+   Once a ``config_t`` instance has been instantiated, these three values cannot be modified.
+
 
 2.4.2.2 Clusters
 ^^^^^^^^^^^^^^^^
@@ -644,6 +666,28 @@ Additional clusters can also be added to an endpoint. Examples:
 
       temperature_measurement::config_t temperature_measurement_config;
       cluster_t *cluster = temperature_measurement::create(endpoint, &temperature_measurement_config, CLUSTER_FLAG_SERVER);
+
+- window_covering:
+
+      ::
+   
+         window_covering::config_t window_covering_config(static_cast<uint8_t>(chip::app::Clusters::WindowCovering::EndProductType::kTiltOnlyInteriorBlind));
+         cluster_t *cluster = window_covering::create(endpoint, &window_covering_config, CLUSTER_FLAG_SERVER);
+
+   The ``window_covering`` ``config_t`` structure includes a constructor that allows specifying
+   an end product type different than the default one, which is "Roller shade".
+   Once a ``config_t`` instance has been instantiated, its end product type cannot be modified.
+
+- pump_configuration_and_control:
+
+   ::
+
+      pump_configuration_and_control::config_t pump_configuration_and_control_config(1, 10, 20);
+      cluster_t *cluster = pump_configuration_and_control::create(endpoint, &pump_configuration_and_control_config, CLUSTER_FLAG_SERVER);
+
+   The ``pump_configuration_and_control`` ``config_t`` structure includes a constructor that allows specifying
+   maximum pressure, maximum speed and maximum flow values. If they aren't set, they will be set to null by default.
+   Once a ``config_t`` instance has been instantiated, these three values cannot be modified.
 
 2.4.2.3 Attributes and Commands
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Solved the problem where `end_product_type` couldn't be customized at the start of the application (Fixes #280)

Because  `end_product_type` now is const in order to follow Matter specification and the value can not be changed after the cluster instance has been initialized, now there are two constructors that allows to create a window covering endpoint configuration with a cluster configuration that has a custom  `end_product_type`, so you can create it just like this:
`window_covering_device::config_t config(static_cast<uint8_t>(chip::app::Clusters::WindowCovering::EndProductType::kTiltOnlyInteriorBlind));`

This also has been done for `pump` and `pump_configuration_and_control`.

Also updated documentation to explain these special cases as suggested @shubhamdp.