### PR TITLE
[format_specifier] - Fixes ESP_LOG format specifier mismatches in components/esp_matter (CON-414)

### DIFF
--- a/components/esp_matter/esp_matter_attribute_utils.cpp
+++ b/components/esp_matter/esp_matter_attribute_utils.cpp
@@ -1590,51 +1590,51 @@ void val_print(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id,
 {
     char action = (is_read) ? 'R' :'W';
     if (val_is_null(val)) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is null **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is null **********", action,
                  endpoint_id, cluster_id, attribute_id);
         return;
     }
 
     if (val->type == ESP_MATTER_VAL_TYPE_BOOLEAN) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is %d **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %d **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.b);
     } else if (val->type == ESP_MATTER_VAL_TYPE_INTEGER || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_INTEGER) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is %d **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %d **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.i);
     } else if (val->type == ESP_MATTER_VAL_TYPE_FLOAT || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_FLOAT) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is %f **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %f **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.f);
     } else if (val->type == ESP_MATTER_VAL_TYPE_UINT8 || val->type == ESP_MATTER_VAL_TYPE_BITMAP8
                || val->type == ESP_MATTER_VAL_TYPE_ENUM8 || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_UINT8
                || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_BITMAP8 || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_ENUM8) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is %d **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %" PRIu8 " **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.u8);
     } else if (val->type == ESP_MATTER_VAL_TYPE_INT16 || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_INT16) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is %d **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %" PRIi16 " **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.i16);
     } else if (val->type == ESP_MATTER_VAL_TYPE_UINT16 || val->type == ESP_MATTER_VAL_TYPE_BITMAP16
                || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_UINT16 || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_BITMAP16) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is %d **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %" PRIu16 " **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.u16);
     } else if (val->type == ESP_MATTER_VAL_TYPE_INT32|| val->type == ESP_MATTER_VAL_TYPE_NULLABLE_INT32) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is %ld **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %" PRIi32 " **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.i32);
     } else if (val->type == ESP_MATTER_VAL_TYPE_UINT32 || val->type == ESP_MATTER_VAL_TYPE_BITMAP32
                || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_UINT32 || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_BITMAP32) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is %ld **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %" PRIu32 " **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.u32);
     } else if (val->type == ESP_MATTER_VAL_TYPE_INT64 || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_INT64) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is %lld **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %" PRIi64 " **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.i64);
     } else if (val->type == ESP_MATTER_VAL_TYPE_UINT64 || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_UINT64) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is %lld **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %" PRIu64 " **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.u64);
     } else if (val->type == ESP_MATTER_VAL_TYPE_CHAR_STRING) {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is %.*s **********", action,
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %.*s **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.a.s, val->val.a.b);
     } else {
-        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04x's Cluster 0x%08lx's Attribute 0x%08lx is <invalid type: %d> **********",
-                 action, endpoint_id, cluster_id, attribute_id, val->type);
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is <invalid type: %d> **********", action,
+                 endpoint_id, cluster_id, attribute_id, val->type);
     }
 }
 
@@ -1780,7 +1780,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint_id, Clust
     uint16_t attribute_size = 0;
     attribute::get_data_from_attr_val(&val, NULL, &attribute_size, NULL);
     if (attribute_size > max_read_length) {
-        ESP_LOGE(TAG, "Insufficient space for reading attribute: required: %d, max: %d", attribute_size,
+        ESP_LOGE(TAG, "Insufficient space for reading attribute: required: %" PRIu16 ", max: %" PRIu16 "", attribute_size,
                  max_read_length);
         return EMBER_ZCL_STATUS_RESOURCE_EXHAUSTED;
     }

--- a/components/esp_matter/esp_matter_command.cpp
+++ b/components/esp_matter/esp_matter_command.cpp
@@ -38,14 +38,14 @@ void DispatchSingleClusterCommandCommon(const ConcreteCommandPath &command_path,
     uint16_t endpoint_id = command_path.mEndpointId;
     uint32_t cluster_id = command_path.mClusterId;
     uint32_t command_id = command_path.mCommandId;
-    ESP_LOGI(TAG, "Received command 0x%08lx for endpoint 0x%04x's cluster 0x%08lx", command_id, endpoint_id, cluster_id);
+    ESP_LOGI(TAG, "Received command 0x%08" PRIX32 " for endpoint 0x%04" PRIX16 "'s cluster 0x%08" PRIX32 "", command_id, endpoint_id, cluster_id);
 
     node_t *node = node::get();
     endpoint_t *endpoint = endpoint::get(node, endpoint_id);
     cluster_t *cluster = cluster::get(endpoint, cluster_id);
     command_t *command = get(cluster, command_id, COMMAND_FLAG_ACCEPTED);
     if (!command) {
-        ESP_LOGE(TAG, "Command 0x%08lx not found", command_id);
+        ESP_LOGE(TAG, "Command 0x%08" PRIX32 " not found", command_id);
         return;
     }
     esp_err_t err = ESP_OK;

--- a/components/esp_matter/esp_matter_core.cpp
+++ b/components/esp_matter/esp_matter_core.cpp
@@ -88,7 +88,7 @@ void PostEvent(uint16_t eventType)
     CHIP_ERROR error = chip::DeviceLayer::PlatformMgr().PostEvent(&event);
     if (error != CHIP_NO_ERROR)
     {
-        ESP_LOGE(TAG, "Failed to post event for event type:%u, err:%" CHIP_ERROR_FORMAT, eventType, error.Format());
+        ESP_LOGE(TAG, "Failed to post event for event type:%" PRIu16 ", err:%" CHIP_ERROR_FORMAT, eventType, error.Format());
     }
 }
 
@@ -402,7 +402,7 @@ static esp_err_t erase_persistent_data(endpoint_t *endpoint)
 {
     uint16_t endpoint_id = endpoint::get_id(endpoint);
     char nvs_namespace[16] = {0};
-    snprintf(nvs_namespace, 16, "endpoint_%X", endpoint_id); /* endpoint_id */
+    snprintf(nvs_namespace, 16, "endpoint_%" PRIX16 "", endpoint_id); /* endpoint_id */
 
     nvs_handle_t handle;
     esp_err_t err = nvs_open_from_partition(ESP_MATTER_NVS_PART_NAME, nvs_namespace, NVS_READWRITE, &handle);
@@ -447,7 +447,7 @@ static esp_err_t disable(endpoint_t *endpoint)
         lock::chip_stack_unlock();
     }
     if (!(current_endpoint->endpoint_type)) {
-        ESP_LOGE(TAG, "endpoint %d's endpoint_type is NULL", current_endpoint->endpoint_id);
+        ESP_LOGE(TAG, "endpoint %" PRIu16 "'s endpoint_type is NULL", current_endpoint->endpoint_id);
         return ESP_ERR_INVALID_STATE;
     }
     /* Free all clusters */
@@ -678,7 +678,7 @@ esp_err_t enable(endpoint_t *endpoint)
     status = emberAfSetDynamicEndpoint(endpoint_index, current_endpoint->endpoint_id, endpoint_type, data_versions,
                                        device_types, current_endpoint->parent_endpoint_id);
     if (status != EMBER_ZCL_STATUS_SUCCESS) {
-        ESP_LOGE(TAG, "Error adding dynamic endpoint %d: 0x%x", current_endpoint->endpoint_id, status);
+        ESP_LOGE(TAG, "Error adding dynamic endpoint %" PRIu16 ": 0x%x", current_endpoint->endpoint_id, status);
         err = ESP_FAIL;
         if (lock_status == lock::SUCCESS) {
             lock::chip_stack_unlock();
@@ -688,7 +688,7 @@ esp_err_t enable(endpoint_t *endpoint)
     if (lock_status == lock::SUCCESS) {
         lock::chip_stack_unlock();
     }
-    ESP_LOGI(TAG, "Dynamic endpoint %d added", current_endpoint->endpoint_id);
+    ESP_LOGI(TAG, "Dynamic endpoint %" PRIu16 " added", current_endpoint->endpoint_id);
     return err;
 
 cleanup:
@@ -997,7 +997,7 @@ esp_err_t factory_reset()
         while (endpoint) {
             err = endpoint::erase_persistent_data(endpoint);
             if (err != ESP_OK) {
-                ESP_LOGE(TAG, "Error erasing persistent data of endpoint %d", endpoint::get_id(endpoint));
+                ESP_LOGE(TAG, "Error erasing persistent data of endpoint %" PRIu16 "", endpoint::get_id(endpoint));
                 continue;
             }
             endpoint = endpoint::get_next(endpoint);
@@ -1023,7 +1023,7 @@ attribute_t *create(cluster_t *cluster, uint32_t attribute_id, uint8_t flags, es
     _cluster_t *current_cluster = (_cluster_t *)cluster;
     attribute_t *existing_attribute = get(cluster, attribute_id);
     if (existing_attribute) {
-        ESP_LOGW(TAG, "Attribute 0x%08lx on cluster 0x%08lx already exists. Not creating again.", attribute_id,
+        ESP_LOGW(TAG, "Attribute 0x%08" PRIX32 " on cluster 0x%08" PRIX32 " already exists. Not creating again.", attribute_id,
                  current_cluster->cluster_id);
         return existing_attribute;
     }
@@ -1305,15 +1305,15 @@ esp_err_t store_val_in_nvs(attribute_t *attribute)
     uint16_t endpoint_id = current_attribute->endpoint_id;
     char nvs_namespace[16] = {0};
     char attribute_key[16] = {0};
-    snprintf(nvs_namespace, 16, "endpoint_%X", endpoint_id); /* endpoint_id */
-    snprintf(attribute_key, 16, "%lX:%lX", cluster_id, attribute_id); /* cluster_id:attribute_id */
+    snprintf(nvs_namespace, 16, "endpoint_%" PRIX16 "", endpoint_id); /* endpoint_id */
+    snprintf(attribute_key, 16, "%" PRIX32 ":%" PRIX32 "", cluster_id, attribute_id); /* cluster_id:attribute_id */
 
     nvs_handle_t handle;
     esp_err_t err = nvs_open_from_partition(ESP_MATTER_NVS_PART_NAME, nvs_namespace, NVS_READWRITE, &handle);
     if (err != ESP_OK) {
         return err;
     }
-    ESP_LOGD(TAG, "Store attribute in nvs: endpoint_id-0x%x, cluster_id-0x%lx, attribute_id-0x%lx",
+    ESP_LOGD(TAG, "Store attribute in nvs: endpoint_id-0x%" PRIx16 ", cluster_id-0x%" PRIx32 ", attribute_id-0x%" PRIx32 "",
              endpoint_id, cluster_id, attribute_id);
     if (current_attribute->val.type == ESP_MATTER_VAL_TYPE_CHAR_STRING ||
         current_attribute->val.type == ESP_MATTER_VAL_TYPE_OCTET_STRING ||
@@ -1347,15 +1347,15 @@ esp_err_t get_val_from_nvs(attribute_t *attribute, esp_matter_attr_val_t *val)
     uint16_t endpoint_id = current_attribute->endpoint_id;
     char nvs_namespace[16] = {0};
     char attribute_key[16] = {0};
-    snprintf(nvs_namespace, 16, "endpoint_%X", endpoint_id); /* endpoint_id */
-    snprintf(attribute_key, 16, "%lX:%lX", cluster_id, attribute_id); /* cluster_id:attribute_id */
+    snprintf(nvs_namespace, 16, "endpoint_%" PRIX16 "", endpoint_id); /* endpoint_id */
+    snprintf(attribute_key, 16, "%" PRIX32 ":%" PRIX32 "", cluster_id, attribute_id); /* cluster_id:attribute_id */
 
     nvs_handle_t handle;
     esp_err_t err = nvs_open_from_partition(ESP_MATTER_NVS_PART_NAME, nvs_namespace, NVS_READONLY, &handle);
     if (err != ESP_OK) {
         return err;
     }
-    ESP_LOGD(TAG, "read attribute from nvs: endpoint_id-0x%x, cluster_id-0x%lx, attribute_id-0x%lx",
+    ESP_LOGD(TAG, "read attribute from nvs: endpoint_id-0x%" PRIx16 ", cluster_id-0x%" PRIx32 ", attribute_id-0x%" PRIx32 "",
              endpoint_id, cluster_id, attribute_id);
     if (current_attribute->val.type == ESP_MATTER_VAL_TYPE_CHAR_STRING ||
         current_attribute->val.type == ESP_MATTER_VAL_TYPE_OCTET_STRING ||
@@ -1395,7 +1395,7 @@ command_t *create(cluster_t *cluster, uint32_t command_id, uint8_t flags, callba
     _cluster_t *current_cluster = (_cluster_t *)cluster;
     command_t *existing_command = get(cluster, command_id, flags);
     if (existing_command) {
-        ESP_LOGW(TAG, "Command 0x%08lx on cluster 0x%08lx already exists. Not creating again.", command_id,
+        ESP_LOGW(TAG, "Command 0x%08" PRIX32 " on cluster 0x%08" PRIX32 " already exists. Not creating again.", command_id,
                  current_cluster->cluster_id);
         return existing_command;
     }
@@ -1529,20 +1529,20 @@ cluster_t *create(endpoint_t *endpoint, uint32_t cluster_id, uint8_t flags)
         /* If a server already exists, do not create it again */
         _cluster_t *_existing_cluster = (_cluster_t *)existing_cluster;
         if ((_existing_cluster->flags & CLUSTER_FLAG_SERVER) && (flags & CLUSTER_FLAG_SERVER)) {
-            ESP_LOGW(TAG, "Server Cluster 0x%08lx on endpoint 0x%04x already exists. Not creating again.", cluster_id,
+            ESP_LOGW(TAG, "Server Cluster 0x%08" PRIX32 " on endpoint 0x%04" PRIx16 " already exists. Not creating again.", cluster_id,
                      current_endpoint->endpoint_id);
             return existing_cluster;
         }
 
         /* If a client already exists, do not create it again */
         if ((_existing_cluster->flags & CLUSTER_FLAG_CLIENT) && (flags & CLUSTER_FLAG_CLIENT)) {
-            ESP_LOGW(TAG, "Client Cluster 0x%08lx on endpoint 0x%04x already exists. Not creating again.", cluster_id,
+            ESP_LOGW(TAG, "Client Cluster 0x%08" PRIX32 " on endpoint 0x%04" PRIx16 " already exists. Not creating again.", cluster_id,
                      current_endpoint->endpoint_id);
             return existing_cluster;
         }
 
         /* The cluster already exists, but is of a different type. Just update the 'Set' part from below. */
-        ESP_LOGI(TAG, "Cluster 0x%08lx on endpoint 0x%04x already exists. Updating values.", cluster_id,
+        ESP_LOGI(TAG, "Cluster 0x%08" PRIX32 " on endpoint 0x%04" PRIx16 " already exists. Updating values.", cluster_id,
                  current_endpoint->endpoint_id);
         _existing_cluster->flags |= flags;
         return existing_cluster;

--- a/examples/generic_switch/CMakeLists.txt
+++ b/examples/generic_switch/CMakeLists.txt
@@ -51,4 +51,4 @@ idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DCHIP_HAVE_CONFIG_
 idf_build_set_property(C_COMPILE_OPTIONS "-Os" APPEND)
 # For RISCV chips, project_include.cmake sets -Wno-format, but does not clear various
 # flags that depend on -Wformat
-idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-security;-Wformat=0" APPEND)
+idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-security" APPEND)

--- a/examples/light/CMakeLists.txt
+++ b/examples/light/CMakeLists.txt
@@ -51,4 +51,4 @@ idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DCHIP_HAVE_CONFIG_
 idf_build_set_property(C_COMPILE_OPTIONS "-Os" APPEND)
 # For RISCV chips, project_include.cmake sets -Wno-format, but does not clear various
 # flags that depend on -Wformat
-idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-security;-Wformat=0" APPEND)
+idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-security" APPEND)

--- a/examples/light_switch/CMakeLists.txt
+++ b/examples/light_switch/CMakeLists.txt
@@ -51,4 +51,4 @@ idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DCHIP_HAVE_CONFIG_
 idf_build_set_property(C_COMPILE_OPTIONS "-Os" APPEND)
 # For RISCV chips, project_include.cmake sets -Wno-format, but does not clear various
 # flags that depend on -Wformat
-idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-security;;-Wformat=0" APPEND)
+idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-security" APPEND)

--- a/examples/zap_light/CMakeLists.txt
+++ b/examples/zap_light/CMakeLists.txt
@@ -51,4 +51,4 @@ idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DCHIP_HAVE_CONFIG_
 idf_build_set_property(C_COMPILE_OPTIONS "-Os" APPEND)
 # For RISCV chips, project_include.cmake sets -Wno-format, but does not clear various
 # flags that depend on -Wformat
-idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-security;-Wformat=0" APPEND)
+idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-security" APPEND)

--- a/examples/zigbee_bridge/CMakeLists.txt
+++ b/examples/zigbee_bridge/CMakeLists.txt
@@ -41,4 +41,4 @@ idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DCHIP_HAVE_CONFIG_
 idf_build_set_property(C_COMPILE_OPTIONS "-Os" APPEND)
 # For RISCV chips, project_include.cmake sets -Wno-format, but does not clear various
 # flags that depend on -Wformat
-idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-security;-Wformat=0;-Wno-error=cpp" APPEND)
+idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-security;-Wno-error=cpp" APPEND)

--- a/examples/zigbee_bridge/main/zigbee_bridge.cpp
+++ b/examples/zigbee_bridge/main/zigbee_bridge.cpp
@@ -24,7 +24,7 @@ extern uint16_t aggregator_endpoint_id;
 
 void zigbee_bridge_find_bridged_on_off_light_cb(esp_zb_zdp_status_t zdo_status, uint16_t addr, uint8_t endpoint, void *user_ctx)
 {
-    ESP_LOGI(TAG, "on_off_light found: address:0x%x, endpoint:%d, response_status:%d", addr, endpoint, zdo_status);
+    ESP_LOGI(TAG, "on_off_light found: address:0x%" PRIx16 ", endpoint:%" PRId8 ", response_status:%d", addr, endpoint, zdo_status);
     if (zdo_status == ESP_ZB_ZDP_STATUS_SUCCESS) {
         node_t *node = node::get();
         if (!node) {
@@ -32,7 +32,7 @@ void zigbee_bridge_find_bridged_on_off_light_cb(esp_zb_zdp_status_t zdo_status, 
             return;
         }
         if (app_bridge_get_device_by_zigbee_shortaddr(addr)) {
-            ESP_LOGI(TAG, "Bridged node for 0x%04x zigbee device on endpoint %d has been created", addr,
+            ESP_LOGI(TAG, "Bridged node for 0x%04" PRIx16 " zigbee device on endpoint %" PRId16 " has been created", addr,
                      app_bridge_get_matter_endpointid_by_zigbee_shortaddr(addr));
         } else {
             app_bridged_device_t *bridged_device =
@@ -43,7 +43,7 @@ void zigbee_bridge_find_bridged_on_off_light_cb(esp_zb_zdp_status_t zdo_status, 
                 ESP_LOGE(TAG, "Failed to create zigbee bridged device (on_off light)");
                 return;
             }
-            ESP_LOGI(TAG, "Create/Update bridged node for 0x%04x zigbee device on endpoint %d", addr,
+            ESP_LOGI(TAG, "Create/Update bridged node for 0x%04" PRIx16 " zigbee device on endpoint %" PRId16 "", addr,
                      app_bridge_get_matter_endpointid_by_zigbee_shortaddr(addr));
         }
     }
@@ -55,7 +55,7 @@ esp_err_t zigbee_bridge_attribute_update(uint16_t endpoint_id, uint32_t cluster_
     if (zigbee_device && zigbee_device->dev && zigbee_device->dev->endpoint) {
         if (cluster_id == OnOff::Id) {
             if (attribute_id == OnOff::Attributes::OnOff::Id) {
-                ESP_LOGD(TAG, "Update Bridged Device, ep: %d, cluster: %d, att: %d", endpoint_id, cluster_id,
+                ESP_LOGD(TAG, "Update Bridged Device, ep: %" PRId16 ", cluster: %" PRId32 ", att: %" PRId32 "", endpoint_id, cluster_id,
                          attribute_id);
                 esp_zb_zcl_on_off_cmd_t cmd_req;
                 cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = zigbee_device->dev_addr.zigbee_shortaddr;
@@ -68,7 +68,7 @@ esp_err_t zigbee_bridge_attribute_update(uint16_t endpoint_id, uint32_t cluster_
         }
     }
     else{
-        ESP_LOGE(TAG, "Unable to Update Bridge Device, ep: %d, cluster: %d, att: %d", endpoint_id, cluster_id, attribute_id);
+        ESP_LOGE(TAG, "Unable to Update Bridge Device, ep: %" PRId16 ", cluster: %" PRId32 ", att: %" PRId32 "", endpoint_id, cluster_id, attribute_id);
     }
     return ESP_OK;
 }


### PR DESCRIPTION
Aim - To resolve format specifier mismatches in `ESP_LOG` prints for `endpoint_id`, `cluster_id`, `attribute_id` & `command_id`. Solves #296 

Change Overview - 
- Fixes in `components/esp_matter` files - [`esp_matter_attribute_utils.cpp`](https://github.com/espressif/esp-matter/blob/main/components/esp_matter/esp_matter_attribute_utils.cpp), [`esp_matter_core.cpp`](https://github.com/espressif/esp-matter/blob/main/components/esp_matter/esp_matter_core.cpp) & [`esp_matter_command.cpp`](https://github.com/espressif/esp-matter/blob/main/components/esp_matter/esp_matter_command.cpp) 
- Fixes in `examples/zigbee_bridge/main` - [`zigbee_bridge.cpp`](https://github.com/espressif/esp-matter/blob/main/examples/zigbee_bridge/main/zigbee_bridge.cpp)

Tests - 
- Sucessfully compiled & commissioned [`light_example`](https://github.com/espressif/esp-matter/tree/main/examples/light) on `esp32s3` with and without the following compile option in [`CMakeLists.txt`](https://github.com/espressif/esp-matter/blob/main/examples/light/CMakeLists.txt#L54)
```
idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-security;-Wformat=0" APPEND)
```
