### PR TITLE
doc: VID and PID also in hex (CON-423)

### DIFF
--- a/docs/en/developing.rst
+++ b/docs/en/developing.rst
@@ -340,8 +340,8 @@ Above QR Code contains the below default values:
 ::
 
     Version:             0
-    Vendor ID:           65521
-    ProductID:           32768
+    Vendor ID:           65521    (0xFFF1)
+    ProductID:           32768    (0x8000)
     Custom flow:         0        (STANDARD)
     Discovery Bitmask:   0x02     (BLE)
     Long discriminator:  3840     (0xf00)


### PR DESCRIPTION
Added VID and PID in hex form to documentation.
Google Console accepts only hex values.