### PR TITLE
Added missing conditional statement for ESP_MATTER_VAL_TYPE_INT8. (CON-437)

### DIFF
--- a/components/esp_matter/esp_matter_attribute_utils.cpp
+++ b/components/esp_matter/esp_matter_attribute_utils.cpp
@@ -1605,7 +1605,10 @@ void val_print(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id,
     } else if (val->type == ESP_MATTER_VAL_TYPE_FLOAT || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_FLOAT) {
         ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %f **********", action,
                  endpoint_id, cluster_id, attribute_id, val->val.f);
-    } else if (val->type == ESP_MATTER_VAL_TYPE_UINT8 || val->type == ESP_MATTER_VAL_TYPE_BITMAP8
+    } else if (val->type == ESP_MATTER_VAL_TYPE_INT8 || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_INT8) {
+        ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %" PRIi8 " **********", action,
+                 endpoint_id, cluster_id, attribute_id, val->val.i8);
+    }  else if (val->type == ESP_MATTER_VAL_TYPE_UINT8 || val->type == ESP_MATTER_VAL_TYPE_BITMAP8
                || val->type == ESP_MATTER_VAL_TYPE_ENUM8 || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_UINT8
                || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_BITMAP8 || val->type == ESP_MATTER_VAL_TYPE_NULLABLE_ENUM8) {
         ESP_LOGI(TAG, "********** %c : Endpoint 0x%04" PRIX16 "'s Cluster 0x%08" PRIX32 "'s Attribute 0x%08" PRIX32 " is %" PRIu8 " **********", action,


### PR DESCRIPTION
**Problem:**
Issue https://github.com/espressif/esp-matter/issues/339

**Change Overview:**
Added the missing check.

**Testing**
Successfully tested the check by adding the **Pressure Measurement Cluster** and an optional int8 attribute (Scale attribute) to the light example and read the value of the attribute using chip-tool before and after the change made.