### PR TITLE
Add callback to support modification of restored bridge devices (CON-773)

### DIFF
--- a/examples/common/app_bridge/app_bridged_device.cpp
+++ b/examples/common/app_bridge/app_bridged_device.cpp
@@ -160,7 +160,7 @@ app_bridged_device_t *app_bridge_create_bridged_device(node_t *node, uint16_t pa
     return new_dev;
 }
 
-esp_err_t app_bridge_initialize(node_t *node)
+esp_err_t app_bridge_initialize(node_t *node, bridge_ep_init_callback_t ep_init)
 {
     esp_err_t err = esp_matter_bridge::initialize(node);
     if (err != ESP_OK) {
@@ -197,6 +197,9 @@ esp_err_t app_bridge_initialize(node_t *node)
             new_dev->next = g_bridged_device_list;
             g_bridged_device_list = new_dev;
             g_current_bridged_device_count++;
+            
+            if (ep_init != NULL)
+            	ep_init(new_dev);
 
             //Enable the resumed endpoint
             esp_matter::endpoint::enable(new_dev->dev->endpoint);

--- a/examples/common/app_bridge/app_bridged_device.h
+++ b/examples/common/app_bridge/app_bridged_device.h
@@ -70,7 +70,8 @@ app_bridged_device_t *app_bridge_create_bridged_device(node_t *node, uint16_t pa
                                                        app_bridged_device_type_t bridged_device_type,
                                                        app_bridged_device_address_t bridged_device_address);
 
-esp_err_t app_bridge_initialize(node_t *node);
+typedef void (*bridge_ep_init_callback_t)(app_bridged_device_t *bdev);
+esp_err_t app_bridge_initialize(node_t *node, bridge_ep_init_callback_t ep_init);
 
 esp_err_t app_bridge_remove_device(app_bridged_device_t *bridged_device);
 


### PR DESCRIPTION
This callback allows the endpoint for a restored bridge device to be modified before it is activated.