### PR TITLE
Create user callback to monitor when commands are executed on a bridge.

### DIFF
--- a/components/esp_matter_bridge/esp_matter_bridge.cpp
+++ b/components/esp_matter_bridge/esp_matter_bridge.cpp
@@ -244,64 +244,19 @@ static esp_err_t plugin_init_callback_endpoint(endpoint_t *endpoint)
     return ESP_OK;
 }
 
-esp_err_t set_device_type(device_t *bridged_device, uint32_t device_type_id)
+static bridge_device_type_callback_t device_type_callback;
+
+esp_err_t set_device_type(device_t *bridged_device, uint32_t device_type_id, void *priv_data)
 {
+    esp_err_t err;
+
     if (!bridged_device) {
         ESP_LOGE(TAG, "bridged_device cannot be NULL");
         return ESP_ERR_INVALID_ARG;
     }
-    esp_err_t err = ESP_OK;
-    switch (device_type_id) {
-    case ESP_MATTER_ON_OFF_LIGHT_DEVICE_TYPE_ID: {
-        on_off_light::config_t on_off_light_conf;
-        err = on_off_light::add(bridged_device->endpoint, &on_off_light_conf);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to add device type");
-            return err;
-        }
-        break;
-    }
-    case ESP_MATTER_DIMMABLE_LIGHT_DEVICE_TYPE_ID: {
-        dimmable_light::config_t dimmable_light_conf;
-        err = dimmable_light::add(bridged_device->endpoint, &dimmable_light_conf);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to add device type");
-            return err;
-        }
-        break;
-    }
-    case ESP_MATTER_COLOR_TEMPERATURE_LIGHT_DEVICE_TYPE_ID: {
-        color_temperature_light::config_t color_temperature_light_conf;
-        err = color_temperature_light::add(bridged_device->endpoint, &color_temperature_light_conf);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to add device type");
-            return err;
-        }
-        break;
-    }
-    case ESP_MATTER_EXTENDED_COLOR_LIGHT_DEVICE_TYPE_ID: {
-        extended_color_light::config_t extended_color_light_conf;
-        err = extended_color_light::add(bridged_device->endpoint, &extended_color_light_conf);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to add device type");
-            return err;
-        }
-        break;
-    }
-    case ESP_MATTER_ON_OFF_SWITCH_DEVICE_TYPE_ID: {
-        on_off_switch::config_t switch_config;
-        err = on_off_switch::add(bridged_device->endpoint, &switch_config);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to add device type");
-            return err;
-        }
-        break;
-    }
-    default: {
-        ESP_LOGE(TAG, "Unsupported bridged matter device type");
-        return ESP_ERR_INVALID_ARG;
-    }
-    }
+    err = device_type_callback(bridged_device->endpoint, device_type_id, priv_data);
+    if (err != ESP_OK)
+        return err;
     return plugin_init_callback_endpoint(bridged_device->endpoint);
 }
 
@@ -351,7 +306,7 @@ device_t *create_device(node_t *node, uint16_t parent_endpoint_id, uint32_t devi
         esp_matter_mem_free(dev);
         return NULL;
     }
-    if (set_device_type(dev, device_type_id) != ESP_OK) {
+    if (set_device_type(dev, device_type_id, priv_data) != ESP_OK) {
         ESP_LOGE(TAG, "Failed to add the device type for the bridged device");
         remove_device(dev);
         return NULL;
@@ -414,7 +369,7 @@ device_t *resume_device(node_t *node, uint16_t device_endpoint_id, void *priv_da
         erase_bridged_device_info(device_endpoint_id);
         return NULL;
     }
-    if (set_device_type(dev, persistent_info.device_type_id) != ESP_OK) {
+    if (set_device_type(dev, persistent_info.device_type_id, priv_data) != ESP_OK) {
         ESP_LOGE(TAG, "Failed to add the device type for the bridged device");
         remove_device(dev);
         return NULL;
@@ -442,12 +397,18 @@ esp_err_t remove_device(device_t *bridged_device)
     return error;
 }
 
-esp_err_t initialize(node_t *node)
+esp_err_t initialize(node_t *node, bridge_device_type_callback_t device_type_cb)
 {
     if (!node) {
         ESP_LOGE(TAG, "node could not be NULL");
         return ESP_ERR_INVALID_ARG;
     }
+    
+    if (!device_type_cb) {
+        ESP_LOGE(TAG, "device_type_callback cannot be NULL");
+        return ESP_ERR_INVALID_ARG;
+    }
+    device_type_callback = device_type_cb;
 
     esp_err_t err = nvs_flash_init_partition(CONFIG_ESP_MATTER_BRIDGE_INFO_PART_NAME);
     if (err != ESP_OK) {

--- a/components/esp_matter_bridge/esp_matter_bridge.h
+++ b/components/esp_matter_bridge/esp_matter_bridge.h
@@ -36,6 +36,8 @@ typedef struct device {
     device_persistent_info_t persistent_info;
 } device_t;
 
+typedef esp_err_t (*bridge_device_type_callback_t)(esp_matter::endpoint_t *ep, uint32_t device_type_id, void *priv_data);
+
 esp_err_t get_bridged_endpoint_ids(uint16_t *matter_endpoint_id_array);
 
 esp_err_t erase_bridged_device_info(uint16_t matter_endpoint_id);
@@ -45,11 +47,11 @@ device_t *create_device(esp_matter::node_t *node, uint16_t parent_endpoint_id, u
 
 device_t *resume_device(esp_matter::node_t *node, uint16_t device_endpoint_id, void *priv_data);
 
-esp_err_t set_device_type(device_t *bridged_device, uint32_t device_type_id);
+esp_err_t set_device_type(device_t *bridged_device, uint32_t device_type_id, void *priv_data);
 
 esp_err_t remove_device(device_t *bridged_device);
 
-esp_err_t initialize(esp_matter::node_t *node);
+esp_err_t initialize(esp_matter::node_t *node, bridge_device_type_callback_t device_type_cb);
 
 esp_err_t factory_reset();
 } // namespace esp_matter_bridge

--- a/examples/blemesh_bridge/main/app_main.cpp
+++ b/examples/blemesh_bridge/main/app_main.cpp
@@ -76,6 +76,44 @@ static esp_err_t app_attribute_update_cb(callback_type_t type, uint16_t endpoint
     return err;
 }
 
+esp_err_t create_bridge_devices(esp_matter::endpoint_t *ep, uint32_t device_type_id, void *priv_data)
+{
+    esp_err_t err = ESP_OK;
+
+    switch (device_type_id) {
+    case ESP_MATTER_ON_OFF_LIGHT_DEVICE_TYPE_ID: {
+        on_off_light::config_t on_off_light_conf;
+        err = on_off_light::add(ep, &on_off_light_conf);
+        break;
+    }
+    case ESP_MATTER_DIMMABLE_LIGHT_DEVICE_TYPE_ID: {
+        dimmable_light::config_t dimmable_light_conf;
+        err = dimmable_light::add(ep, &dimmable_light_conf);
+        break;
+    }
+    case ESP_MATTER_COLOR_TEMPERATURE_LIGHT_DEVICE_TYPE_ID: {
+        color_temperature_light::config_t color_temperature_light_conf;
+        err = color_temperature_light::add(ep, &color_temperature_light_conf);
+        break;
+    }
+    case ESP_MATTER_EXTENDED_COLOR_LIGHT_DEVICE_TYPE_ID: {
+        extended_color_light::config_t extended_color_light_conf;
+        err = extended_color_light::add(ep, &extended_color_light_conf);
+        break;
+    }
+    case ESP_MATTER_ON_OFF_SWITCH_DEVICE_TYPE_ID: {
+        on_off_switch::config_t switch_config;
+        err = on_off_switch::add(ep, &switch_config);
+        break;
+    }
+    default: {
+        ESP_LOGE(TAG, "Unsupported bridged matter device type");
+        return ESP_ERR_INVALID_ARG;
+    }
+    }
+    return err;
+}
+
 extern "C" void app_main()
 {
     esp_err_t err = ESP_OK;
@@ -106,7 +144,7 @@ extern "C" void app_main()
         ESP_LOGE(TAG, "Matter start failed: %d", err);
     }
 
-    err = app_bridge_initialize(node);
+    err = app_bridge_initialize(node, create_bridge_devices);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to resume the bridged endpoints: %d", err);
     }

--- a/examples/blemesh_bridge/main/blemesh_bridge.cpp
+++ b/examples/blemesh_bridge/main/blemesh_bridge.cpp
@@ -57,7 +57,7 @@ esp_err_t blemesh_bridge_match_bridged_onoff_light(uint8_t *composition_data, ui
             app_bridged_device_t *bridged_device =
                 app_bridge_create_bridged_device(node, aggregator_endpoint_id, ESP_MATTER_ON_OFF_LIGHT_DEVICE_TYPE_ID,
                                                  ESP_MATTER_BRIDGED_DEVICE_TYPE_BLEMESH,
-                                                 app_bridge_blemesh_address(blemesh_addr));
+                                                 app_bridge_blemesh_address(blemesh_addr), NULL);
             ESP_RETURN_ON_FALSE(bridged_device, ESP_FAIL, TAG, "Failed to create bridged device (on_off light)");
             ESP_LOGI(TAG, "Create/Update bridged node for 0x%04x bridged device on endpoint %d", blemesh_addr,
                     app_bridge_get_matter_endpointid_by_blemesh_addr(blemesh_addr));

--- a/examples/common/app_bridge/app_bridged_device.h
+++ b/examples/common/app_bridge/app_bridged_device.h
@@ -55,6 +55,8 @@ typedef struct app_bridged_device {
     app_bridged_device_address_t dev_addr;
     /** Pointer of Next Bridged Device */
     struct app_bridged_device *next;
+    /* User initialization data */
+    void *priv_data;
 } app_bridged_device_t;
 
 /** Bridged Device's Address APIs */
@@ -68,9 +70,10 @@ app_bridged_device_address_t app_bridge_espnow_address(uint8_t espnow_macaddr[6]
 app_bridged_device_t *app_bridge_create_bridged_device(node_t *node, uint16_t parent_endpoint_id,
                                                        uint32_t matter_device_type_id,
                                                        app_bridged_device_type_t bridged_device_type,
-                                                       app_bridged_device_address_t bridged_device_address);
+                                                       app_bridged_device_address_t bridged_device_address,
+                                                       void *priv_data);
 
-esp_err_t app_bridge_initialize(node_t *node);
+esp_err_t app_bridge_initialize(node_t *node, esp_matter_bridge::bridge_device_type_callback_t device_type_cb);
 
 esp_err_t app_bridge_remove_device(app_bridged_device_t *bridged_device);
 

--- a/examples/esp-now_bridge_light/main/app_main.cpp
+++ b/examples/esp-now_bridge_light/main/app_main.cpp
@@ -89,6 +89,44 @@ static esp_err_t app_attribute_update_cb(attribute::callback_type_t type, uint16
     return err;
 }
 
+esp_err_t create_bridge_devices(esp_matter::endpoint_t *ep, uint32_t device_type_id, void *priv_data)
+{
+    esp_err_t err = ESP_OK;
+
+    switch (device_type_id) {
+    case ESP_MATTER_ON_OFF_LIGHT_DEVICE_TYPE_ID: {
+        on_off_light::config_t on_off_light_conf;
+        err = on_off_light::add(ep, &on_off_light_conf);
+        break;
+    }
+    case ESP_MATTER_DIMMABLE_LIGHT_DEVICE_TYPE_ID: {
+        dimmable_light::config_t dimmable_light_conf;
+        err = dimmable_light::add(ep, &dimmable_light_conf);
+        break;
+    }
+    case ESP_MATTER_COLOR_TEMPERATURE_LIGHT_DEVICE_TYPE_ID: {
+        color_temperature_light::config_t color_temperature_light_conf;
+        err = color_temperature_light::add(ep, &color_temperature_light_conf);
+        break;
+    }
+    case ESP_MATTER_EXTENDED_COLOR_LIGHT_DEVICE_TYPE_ID: {
+        extended_color_light::config_t extended_color_light_conf;
+        err = extended_color_light::add(ep, &extended_color_light_conf);
+        break;
+    }
+    case ESP_MATTER_ON_OFF_SWITCH_DEVICE_TYPE_ID: {
+        on_off_switch::config_t switch_config;
+        err = on_off_switch::add(ep, &switch_config);
+        break;
+    }
+    default: {
+        ESP_LOGE(TAG, "Unsupported bridged matter device type");
+        return ESP_ERR_INVALID_ARG;
+    }
+    }
+    return err;
+}
+
 extern "C" void app_main()
 {
     esp_err_t err = ESP_OK;
@@ -148,7 +186,7 @@ extern "C" void app_main()
         ESP_LOGE(TAG, "Matter start failed: %d", err);
     }
 
-    err = app_bridge_initialize(node);
+    err = app_bridge_initialize(node, create_bridge_devices);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to resume the bridged endpoints: %d", err);
     }

--- a/examples/esp-now_bridge_light/main/espnow_bridge.cpp
+++ b/examples/esp-now_bridge_light/main/espnow_bridge.cpp
@@ -38,7 +38,7 @@ esp_err_t espnow_bridge_match_bridged_switch(uint8_t espnow_macaddr[6], uint16_t
         app_bridged_device_t *bridged_device =
             app_bridge_create_bridged_device(node, aggregator_endpoint_id, matter_device_type_id,
                                              ESP_MATTER_BRIDGED_DEVICE_TYPE_ESPNOW,
-                                             app_bridge_espnow_address(espnow_macaddr, espnow_initiator_attr));
+                                             app_bridge_espnow_address(espnow_macaddr, espnow_initiator_attr), NULL);
         ESP_RETURN_ON_FALSE(bridged_device, ESP_FAIL, TAG, "Failed to create bridged device (espnow switch)");
         ESP_LOGI(TAG, "Create/Update bridged node for " MACSTR " bridged device on endpoint %d", MAC2STR(espnow_macaddr),
                 app_bridge_get_matter_endpointid_by_espnow_macaddr(espnow_macaddr));

--- a/examples/zigbee_bridge/main/app_main.cpp
+++ b/examples/zigbee_bridge/main/app_main.cpp
@@ -76,6 +76,44 @@ static esp_err_t app_attribute_update_cb(callback_type_t type, uint16_t endpoint
     return err;
 }
 
+esp_err_t create_bridge_devices(esp_matter::endpoint_t *ep, uint32_t device_type_id, void *priv_data)
+{
+    esp_err_t err = ESP_OK;
+
+    switch (device_type_id) {
+    case ESP_MATTER_ON_OFF_LIGHT_DEVICE_TYPE_ID: {
+        on_off_light::config_t on_off_light_conf;
+        err = on_off_light::add(ep, &on_off_light_conf);
+        break;
+    }
+    case ESP_MATTER_DIMMABLE_LIGHT_DEVICE_TYPE_ID: {
+        dimmable_light::config_t dimmable_light_conf;
+        err = dimmable_light::add(ep, &dimmable_light_conf);
+        break;
+    }
+    case ESP_MATTER_COLOR_TEMPERATURE_LIGHT_DEVICE_TYPE_ID: {
+        color_temperature_light::config_t color_temperature_light_conf;
+        err = color_temperature_light::add(ep, &color_temperature_light_conf);
+        break;
+    }
+    case ESP_MATTER_EXTENDED_COLOR_LIGHT_DEVICE_TYPE_ID: {
+        extended_color_light::config_t extended_color_light_conf;
+        err = extended_color_light::add(ep, &extended_color_light_conf);
+        break;
+    }
+    case ESP_MATTER_ON_OFF_SWITCH_DEVICE_TYPE_ID: {
+        on_off_switch::config_t switch_config;
+        err = on_off_switch::add(ep, &switch_config);
+        break;
+    }
+    default: {
+        ESP_LOGE(TAG, "Unsupported bridged matter device type");
+        return ESP_ERR_INVALID_ARG;
+    }
+    }
+    return err;
+}
+
 extern "C" void app_main()
 {
     esp_err_t err = ESP_OK;
@@ -106,7 +144,7 @@ extern "C" void app_main()
         ESP_LOGE(TAG, "Matter start failed: %d", err);
     }
 
-    err = app_bridge_initialize(node);
+    err = app_bridge_initialize(node, create_bridge_devices);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to resume the bridged endpoints: %d", err);
     }

--- a/examples/zigbee_bridge/main/zigbee_bridge.cpp
+++ b/examples/zigbee_bridge/main/zigbee_bridge.cpp
@@ -38,7 +38,7 @@ void zigbee_bridge_find_bridged_on_off_light_cb(esp_zb_zdp_status_t zdo_status, 
             app_bridged_device_t *bridged_device =
                 app_bridge_create_bridged_device(node, aggregator_endpoint_id, ESP_MATTER_ON_OFF_LIGHT_DEVICE_TYPE_ID,
                                                  ESP_MATTER_BRIDGED_DEVICE_TYPE_ZIGBEE,
-                                                 app_bridge_zigbee_address(endpoint, addr));
+                                                 app_bridge_zigbee_address(endpoint, addr), NULL);
             if (!bridged_device) {
                 ESP_LOGE(TAG, "Failed to create zigbee bridged device (on_off light)");
                 return;


### PR DESCRIPTION
This callback can be used to notify a bridge when commands are executed. It does not replace the execution of the command, it is simply a notification containing the parameters for the commands.