### PR TITLE
Create user callback on command to allow monitoring in bridge (CON-890)

### DIFF
--- a/components/esp_matter/esp_matter_command.cpp
+++ b/components/esp_matter/esp_matter_command.cpp
@@ -49,8 +49,14 @@ void DispatchSingleClusterCommandCommon(const ConcreteCommandPath &command_path,
         return;
     }
     esp_err_t err = ESP_OK;
-    callback_t callback = get_callback(command);
+    TLVReader tlv_reader;
+    tlv_reader.Init(tlv_data);
+    callback_t callback = get_user_callback(command);
     if (callback) {
+        err = callback(command_path, tlv_reader, opaque_ptr);
+    }
+    callback = get_callback(command);
+    if ((err == ESP_OK) && callback) {
         err = callback(command_path, tlv_data, opaque_ptr);
     }
     int flags = get_flags(command);

--- a/components/esp_matter/esp_matter_core.cpp
+++ b/components/esp_matter/esp_matter_core.cpp
@@ -157,6 +157,7 @@ typedef struct _command {
     uint32_t command_id;
     uint16_t flags;
     command::callback_t callback;
+    command::callback_t user_callback;
     struct _command *next;
 } _command_t;
 
@@ -1397,6 +1398,7 @@ command_t *create(cluster_t *cluster, uint32_t command_id, uint8_t flags, callba
     command->command_id = command_id;
     command->flags = flags;
     command->callback = callback;
+    command->user_callback = NULL;
 
     /* Add */
     _command_t *previous_command = NULL;
@@ -1482,6 +1484,25 @@ callback_t get_callback(command_t *command)
     }
     _command_t *current_command = (_command_t *)command;
     return current_command->callback;
+}
+
+callback_t get_user_callback(command_t *command)
+{
+    if (!command) {
+        ESP_LOGE(TAG, "Command cannot be NULL");
+        return NULL;
+    }
+    _command_t *current_command = (_command_t *)command;
+    return current_command->user_callback;
+}
+
+void set_user_callback(command_t *command, callback_t user_callback)
+{
+    if (!command) {
+        ESP_LOGE(TAG, "Command cannot be NULL");
+    }
+    _command_t *current_command = (_command_t *)command;
+    current_command->user_callback = user_callback;
 }
 
 uint16_t get_flags(command_t *command)

--- a/components/esp_matter/esp_matter_core.h
+++ b/components/esp_matter/esp_matter_core.h
@@ -676,6 +676,28 @@ uint32_t get_id(command_t *command);
  */
 callback_t get_callback(command_t *command);
 
+/** Get command user_callback
+ *
+ * Get the command user_callback for the command.
+ *
+ * @param[in] command Command handle.
+ *
+ * @return Command user_callback on success.
+ * @return NULL in case of failure or if the callback was not set when creating the command.
+ */
+callback_t get_user_callback(command_t *command);
+
+/** Set command user_callback
+ *
+ * Set the user_callback for the command.
+ *
+ * @param[in] command Command handle.
+ * @param[in] user_callback callback_t.
+ *
+ * @return void
+ */
+void set_user_callback(command_t *command, callback_t user_callback);
+
 /** Get command flags
  *
  * Get the command flags for the command.


### PR DESCRIPTION
Create a callback hook to allow a bridge to monitor commands. Does not replace the command, it is an additional monitoring hook to allow inspection of the command parameters.

This is very similar to https://github.com/espressif/esp-matter/pull/35 except this callback is for monitoring and does not stop the existing callback from running.   In pull 35 he wanted to replace the callback. I initially started off replacing the callback as described in https://github.com/espressif/esp-matter/issues/704  but then I figured out that I wanted to monitor the command, not replace it. In my case I need to keep the underlying function and then I add on additional operations via the user_cb. PR35 can easily be implemented by adding a set function for the main callback.