### PR TITLE
fix: do not force starting ble advertising on initialization (CON-891)

### DIFF
--- a/components/esp_matter/esp_matter_core.cpp
+++ b/components/esp_matter/esp_matter_core.cpp
@@ -968,7 +968,6 @@ static esp_err_t chip_init(event_callback_t callback, intptr_t callback_arg)
     }
 
     setup_providers();
-    ConnectivityMgr().SetBLEAdvertisingEnabled(true);
     // ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
     if (PlatformMgr().StartEventLoopTask() != CHIP_NO_ERROR) {
         chip::Platform::MemoryShutdown();


### PR DESCRIPTION
Related:

- https://github.com/project-chip/connectedhomeip/pull/30482

I have proposed to make `CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART` configurable via `menuconfig` as shown above. Even if this proposal is accepted, esp-matter forces to start ble advertising on ble initialization. This should be removed and delegated to the user configuration about `CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART`.