### PR TITLE
fix markdown typo in README.md (CON-964)

### DIFF
--- a/examples/generic_switch/README.md
+++ b/examples/generic_switch/README.md
@@ -52,6 +52,7 @@ To read label-list of User Label Cluster execute the command given below.
 
 ```
 chip-tool userlabel read label-list 0x7283 1
+```
 
 ### Using the TagList Feature
 


### PR DESCRIPTION
quick fix for a missing code block entry. 
Currently looks like this, was missing a ``` block
![image](https://github.com/espressif/esp-matter/assets/5651603/43edec1d-7697-4690-857f-784e8d33f334)
