### PR TITLE
Feature: add callback data to the bridge device type callback

### DIFF
--- a/components/esp_matter_bridge/esp_matter_bridge.cpp
+++ b/components/esp_matter_bridge/esp_matter_bridge.cpp
@@ -246,7 +246,7 @@ static esp_err_t plugin_init_callback_endpoint(endpoint_t *endpoint)
 
 static bridge_device_type_callback_t device_type_callback;
 
-esp_err_t set_device_type(device_t *bridged_device, uint32_t device_type_id, void *priv_data)
+esp_err_t set_device_type(device_t *bridged_device, uint32_t device_type_id, void *priv_data, void* callback_data)
 {
     esp_err_t err;
 
@@ -254,7 +254,7 @@ esp_err_t set_device_type(device_t *bridged_device, uint32_t device_type_id, voi
         ESP_LOGE(TAG, "bridged_device cannot be NULL");
         return ESP_ERR_INVALID_ARG;
     }
-    err = device_type_callback(bridged_device->endpoint, device_type_id, priv_data);
+    err = device_type_callback(bridged_device->endpoint, device_type_id, priv_data, callback_data);
     if (err != ESP_OK)
         return err;
     return plugin_init_callback_endpoint(bridged_device->endpoint);
@@ -286,7 +286,8 @@ static bool parent_endpoint_is_valid(node_t *node, uint16_t parent_endpoint_id)
     return false;
 }
 
-device_t *create_device(node_t *node, uint16_t parent_endpoint_id, uint32_t device_type_id, void *priv_data)
+device_t *create_device(node_t *node, uint16_t parent_endpoint_id, uint32_t device_type_id,
+                        void *priv_data, void* callback_data)
 {
     // Check whether the parent endpoint is valid
     if (!parent_endpoint_is_valid(node, parent_endpoint_id)) {
@@ -306,7 +307,7 @@ device_t *create_device(node_t *node, uint16_t parent_endpoint_id, uint32_t devi
         esp_matter_mem_free(dev);
         return NULL;
     }
-    if (set_device_type(dev, device_type_id, priv_data) != ESP_OK) {
+    if (set_device_type(dev, device_type_id, priv_data, callback_data) != ESP_OK) {
         ESP_LOGE(TAG, "Failed to add the device type for the bridged device");
         remove_device(dev);
         return NULL;
@@ -344,7 +345,7 @@ device_t *create_device(node_t *node, uint16_t parent_endpoint_id, uint32_t devi
     return dev;
 }
 
-device_t *resume_device(node_t *node, uint16_t device_endpoint_id, void *priv_data)
+device_t *resume_device(node_t *node, uint16_t device_endpoint_id, void *priv_data, void* callback_data)
 {
     esp_err_t err = ESP_OK;
     device_persistent_info_t persistent_info;
@@ -369,7 +370,7 @@ device_t *resume_device(node_t *node, uint16_t device_endpoint_id, void *priv_da
         erase_bridged_device_info(device_endpoint_id);
         return NULL;
     }
-    if (set_device_type(dev, persistent_info.device_type_id, priv_data) != ESP_OK) {
+    if (set_device_type(dev, persistent_info.device_type_id, priv_data, callback_data) != ESP_OK) {
         ESP_LOGE(TAG, "Failed to add the device type for the bridged device");
         remove_device(dev);
         return NULL;

--- a/components/esp_matter_bridge/esp_matter_bridge.h
+++ b/components/esp_matter_bridge/esp_matter_bridge.h
@@ -36,18 +36,19 @@ typedef struct device {
     device_persistent_info_t persistent_info;
 } device_t;
 
-typedef esp_err_t (*bridge_device_type_callback_t)(esp_matter::endpoint_t *ep, uint32_t device_type_id, void *priv_data);
+typedef esp_err_t (*bridge_device_type_callback_t)(esp_matter::endpoint_t *ep, uint32_t device_type_id,
+                                                   void *priv_data, void* callback_data);
 
 esp_err_t get_bridged_endpoint_ids(uint16_t *matter_endpoint_id_array);
 
 esp_err_t erase_bridged_device_info(uint16_t matter_endpoint_id);
 
 device_t *create_device(esp_matter::node_t *node, uint16_t parent_endpoint_id, uint32_t device_type_id,
-                        void *priv_data);
+                        void *priv_data, void* callback_data);
 
-device_t *resume_device(esp_matter::node_t *node, uint16_t device_endpoint_id, void *priv_data);
+device_t *resume_device(esp_matter::node_t *node, uint16_t device_endpoint_id, void *priv_data, void* callback_data);
 
-esp_err_t set_device_type(device_t *bridged_device, uint32_t device_type_id, void *priv_data);
+esp_err_t set_device_type(device_t *bridged_device, uint32_t device_type_id, void *priv_data, void* callback_data);
 
 esp_err_t remove_device(device_t *bridged_device);
 


### PR DESCRIPTION
## What
I have added callback data to the bridge device type callback (`esp_matter_bridge::set_device_type`). Correspondingly, callback data has been integrated into the `esp_matter_bridge::create_device` and `esp_matter_bridge::resume_device` functions.

## Why
This enhancement allows for the efficient transmission of type-specific configuration data to the device during its creation. This is particularly beneficial in scenarios where passing such information to the `priv_data` parameter might not be ideal. The `priv_data` parameter, typically passed to endpoint metadata and other callbacks like `attribute_callback`, can now be kept separate from configuration details.

## Use-case
In my specific use-case, I have implemented an abstraction layer above `esp-matter`. When a device is created, I aim to transmit both application user context (device object with application meta-data) and Matter-specific configuration (e.g., features for a generic switch). By utilizing the callback data, I can achieve a clean separation between `priv_data` and configurations within the abstraction layer. This proves to be advantageous as the abstraction layer does not need to be aware of the context structure in `priv_data`, resulting in a more organized and maintainable codebase.

I believe that this enhancement aligns with common use-cases where developers desire to keep `priv_data` and configurations distinctly separated.