### PR TITLE
Fix: mode-select feature on-off id (CON-998)

### DIFF
--- a/components/esp_matter/esp_matter_feature.cpp
+++ b/components/esp_matter/esp_matter_feature.cpp
@@ -3060,9 +3060,7 @@ namespace on_off {
 
 uint32_t get_id()
 {
-    // enum class for DepOnOff is not present in the upstream code.
-    // Return the code according to the SPEC
-    return 0x00;
+    return (uint32_t)ModeSelect::Feature::kOnOff;
 }
 
 esp_err_t add(cluster_t *cluster, config_t *config)


### PR DESCRIPTION
`esp_matter::cluster::mode_select::feature::on_off::get_id()` returns `0x00` now. This should be `0x01`.