### PR TITLE
Make error message generic for other bridge device types (CON-1083)

### DIFF
--- a/examples/common/app_bridge/app_bridged_device.cpp
+++ b/examples/common/app_bridge/app_bridged_device.cpp
@@ -173,7 +173,7 @@ app_bridged_device_t *app_bridge_create_bridged_device(node_t *node, uint16_t pa
                                                        void *priv_data)
 {
     if (g_current_bridged_device_count >= MAX_BRIDGED_DEVICE_COUNT) {
-        ESP_LOGE(TAG, "The device list is full, Could not add a zigbee bridged device");
+        ESP_LOGE(TAG, "The device list is full, could not add bridged device");
         return NULL;
     }
     app_bridged_device_t *new_dev = (app_bridged_device_t *)esp_matter_mem_calloc(1, sizeof(app_bridged_device_t));


### PR DESCRIPTION
BLE Mesh and ESP now examples also call app_bridge_create_bridged_device so log message shouldn't refer to any particular device type.