### PR TITLE
Multi plug improvements (CON-1465)

### DIFF
--- a/examples/multiple_on_off_plugin_units/CMakeLists.txt
+++ b/examples/multiple_on_off_plugin_units/CMakeLists.txt
@@ -19,6 +19,7 @@ include(${ESP_MATTER_PATH}/examples/common/cmake_common/components_include.cmake
 set(EXTRA_COMPONENT_DIRS
     "${MATTER_SDK_PATH}/config/esp32/components"
     "${ESP_MATTER_PATH}/components"
+    "${ESP_MATTER_PATH}/examples/common"
     ${extra_components_dirs_append})
 
 project(multiple_on_off_plugin_units)

--- a/examples/multiple_on_off_plugin_units/README.md
+++ b/examples/multiple_on_off_plugin_units/README.md
@@ -11,10 +11,33 @@ To update the existing CONFIG_GPIO_PLUG values, follow these steps:
 1. Run the following command to access the configuration menu: 
 `idf.py menuconfig`
 1. Navigate to the "Plugin manager" menu.
-1. Update the GPIO pin number values (**Use only available GPIO pins as per the target chip**).
+1. Update the GPIO pin number used for the factory reset button and plug output (**Use only available GPIO pins as per the target chip**).
 
+You can update the number of plugin units from same menu.
 
-You can update maximum configurable plugin units from same menu.
+The following table defines the default GPIO pin numbers for each supported target device.
+
+| IO Function          | ESP32 | ESP32-C2 | ESP32-C3 | ESP32-C6 | ESP32-H2 | ESP32-S3 |
+|----------------------|-------|----------|----------|----------|----------|----------|
+| Factory Reset Button | 0     | 9        | 9        | 9        | 9        | 0        |
+| Plug 1               | 2     | 2        | 2        | 2        | 2        | 2        |
+| Plug 2               | 4     | 4        | 4        | 4        | 4        | 4        |
+| Plug 3               | 5     | 5        | 5        | 5        | 5        | 5        |
+| Plug 4               | 12    | 6        | 6        | 12       | 12       | 12       |
+| Plug 5               | 13    | 7        | 7        | 13       | 13       | 13       |
+| Plug 6               | 14    | 8        | 8        | 15       | 14       | 14       |
+| Plug 7               | 15    | 10       | 10       | 18       | 22       | 15       |
+| Plug 8               | 16    | 18       | 18       | 19       | 25       | 16       |
+| Plug 9               | 17    | 0        | 19       | 20       | 26       | 17       |
+| Plug 10              | 18    | 1        | 0        | 21       | 27       | 18       |
+| Plug 11              | 19    | 3        | 1        | 22       | 0        | 19       |
+| Plug 12              | 21    |          | 3        | 23       | 1        | 20       |
+| Plug 13              | 22    |          |          | 0        | 3        | 21       |
+| Plug 14              | 23    |          |          | 1        | 8        | 35       |
+| Plug 15              | 25    |          |          | 3        | 10       | 36       |
+| Plug 16              | 26    |          |          | 6        | 11       | 37       |
+
+**Note**: ESP32-C2 and ESP32-C3 do not have enough IO to use all 16 plugs
 
 See the [docs](https://docs.espressif.com/projects/esp-matter/en/latest/esp32/developing.html) for more information about building and flashing the firmware.
 

--- a/examples/multiple_on_off_plugin_units/main/Kconfig.projbuild
+++ b/examples/multiple_on_off_plugin_units/main/Kconfig.projbuild
@@ -1,25 +1,174 @@
 menu "Plugin manager"
-    config MAX_CONFIGURABLE_PLUGS
-        int "Maximum virtual configurable plugs"
-        default 5
+    config USER_BUTTON
+        bool "Use custom GPIO for factory reset button"
+        default n
+
+    config USER_BUTTON_GPIO
+        int "GPIO pin number for factory reset button"
+        default 0 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S3
+        default 9
+        depends on USER_BUTTON
+
+    config USER_BUTTON_LEVEL
+        int "GPIO level when factory reset button is active"
+        default 0
+        range 0 1
+        depends on USER_BUTTON
+    
+    config NUM_VIRTUAL_PLUGS
+        int "Number of virtual plugs"
+        default 3
+        range 1 11 if IDF_TARGET_ESP32C2
+        range 1 12 if IDF_TARGET_ESP32C3
         range 1 16
 
     config GPIO_PLUG_1
         int "GPIO pin number for plug 1"
-        default 3 if IDF_TARGET_ESP32S3
-        default 2 if !IDF_TARGET_ESP32S3
+        default 2
+        depends on (NUM_VIRTUAL_PLUGS >= 1)
         help
             Set GPIO pin value for target chip to create plugin unit
 
     config GPIO_PLUG_2
         int "GPIO pin number for plug 2"
         default 4
+        depends on (NUM_VIRTUAL_PLUGS >= 2)
         help
             Set GPIO pin value for target chip to create plugin unit
     
     config GPIO_PLUG_3
         int "GPIO pin number for plug 3"
         default 5
+        depends on (NUM_VIRTUAL_PLUGS >= 3)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_4
+        int "GPIO pin number for plug 4"
+        default 6 if IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32C3
+        default 12
+        depends on (NUM_VIRTUAL_PLUGS >= 4)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_5
+        int "GPIO pin number for plug 5"
+        default 7 if IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32C3
+        default 13
+        depends on (NUM_VIRTUAL_PLUGS >= 5)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_6
+        int "GPIO pin number for plug 6"
+        default 8 if IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32C3
+        default 15 if IDF_TARGET_ESP32C6
+        default 14
+        depends on (NUM_VIRTUAL_PLUGS >= 6)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_7
+        int "GPIO pin number for plug 7"
+        default 10 if IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32C3
+        default 18 if IDF_TARGET_ESP32C6
+        default 22 if IDF_TARGET_ESP32H2
+        default 15
+        depends on (NUM_VIRTUAL_PLUGS >= 7)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_8
+        int "GPIO pin number for plug 8"
+        default 18 if IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32C3
+        default 19 if IDF_TARGET_ESP32C6
+        default 25 if IDF_TARGET_ESP32H2
+        default 16
+        depends on (NUM_VIRTUAL_PLUGS >= 8)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_9
+        int "GPIO pin number for plug 9"
+        default 0 if IDF_TARGET_ESP32C2
+        default 19 if IDF_TARGET_ESP32C3
+        default 20 if IDF_TARGET_ESP32C6
+        default 26 if IDF_TARGET_ESP32H2
+        default 17
+        depends on (NUM_VIRTUAL_PLUGS >= 9)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_10
+        int "GPIO pin number for plug 10"
+        default 1 if IDF_TARGET_ESP32C2
+        default 0 if IDF_TARGET_ESP32C3
+        default 21 if IDF_TARGET_ESP32C6
+        default 27 if IDF_TARGET_ESP32H2
+        default 18
+        depends on (NUM_VIRTUAL_PLUGS >= 10)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_11
+        int "GPIO pin number for plug 11"
+        default 3 if IDF_TARGET_ESP32C2
+        default 1 if IDF_TARGET_ESP32C3
+        default 22 if IDF_TARGET_ESP32C6
+        default 0 if IDF_TARGET_ESP32H2
+        default 19
+        depends on (NUM_VIRTUAL_PLUGS >= 11)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_12
+        int "GPIO pin number for plug 12"
+        default 3 if IDF_TARGET_ESP32C3
+        default 23 if IDF_TARGET_ESP32C6
+        default 1 if IDF_TARGET_ESP32H2
+        default 20 if IDF_TARGET_ESP32S3
+        default 21
+        depends on (NUM_VIRTUAL_PLUGS >= 12)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_13
+        int "GPIO pin number for plug 13"
+        default 0 if IDF_TARGET_ESP32C6
+        default 3 if IDF_TARGET_ESP32H2
+        default 21 if IDF_TARGET_ESP32S3
+        default 22
+        depends on (NUM_VIRTUAL_PLUGS >= 13)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_14
+        int "GPIO pin number for plug 14"
+        default 1 if IDF_TARGET_ESP32C6
+        default 8 if IDF_TARGET_ESP32H2
+        default 35 if IDF_TARGET_ESP32S3
+        default 23
+        depends on (NUM_VIRTUAL_PLUGS >= 14)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_15
+        int "GPIO pin number for plug 15"
+        default 3 if IDF_TARGET_ESP32C6
+        default 10 if IDF_TARGET_ESP32H2
+        default 36 if IDF_TARGET_ESP32S3
+        default 25
+        depends on (NUM_VIRTUAL_PLUGS >= 15)
+        help
+            Set GPIO pin value for target chip to create plugin unit
+    
+    config GPIO_PLUG_16
+        int "GPIO pin number for plug 16"
+        default 6 if IDF_TARGET_ESP32C6
+        default 11 if IDF_TARGET_ESP32H2
+        default 37 if IDF_TARGET_ESP32S3
+        default 26
+        depends on (NUM_VIRTUAL_PLUGS >= 16)
         help
             Set GPIO pin value for target chip to create plugin unit
 endmenu

--- a/examples/multiple_on_off_plugin_units/main/app_priv.h
+++ b/examples/multiple_on_off_plugin_units/main/app_priv.h
@@ -10,6 +10,7 @@
 
 #include <esp_err.h>
 #include <esp_matter.h>
+#include "soc/gpio_num.h"
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include "esp_openthread_types.h"
@@ -28,8 +29,8 @@ struct plugin_endpoint {
 
 gpio_num_t get_gpio(uint16_t endpoint_id);
 
-extern plugin_endpoint s_plugin_unit_list[CONFIG_MAX_CONFIGURABLE_PLUGS];
-extern uint16_t s_configure_plugs;
+extern plugin_endpoint plugin_unit_list[CONFIG_NUM_VIRTUAL_PLUGS];
+extern uint16_t configure_plugs;
 
 typedef void *app_driver_handle_t;
 
@@ -59,6 +60,17 @@ esp_err_t app_driver_plugin_unit_init(const gpio_plug* plug);
  */
 esp_err_t app_driver_attribute_update(app_driver_handle_t driver_handle, uint16_t endpoint_id, uint32_t cluster_id,
                                       uint32_t attribute_id, esp_matter_attr_val_t *val);
+
+/** Initialize the button driver
+ *
+ * This initializes the button driver associated with the selected board.
+ * 
+ * @param[out] reset_gpio GPIO pin # assigned to the reset button
+ *
+ * @return Handle on success.
+ * @return NULL in case of failure.
+ */
+app_driver_handle_t app_driver_button_init(gpio_num_t * reset_gpio);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #define ESP_OPENTHREAD_DEFAULT_RADIO_CONFIG()                                           \

--- a/examples/multiple_on_off_plugin_units/main/idf_component.yml
+++ b/examples/multiple_on_off_plugin_units/main/idf_component.yml
@@ -4,3 +4,5 @@ dependencies:
     rules: # will add "optional_component" only when all if clauses are True
       - if: "idf_version >=5.0"
       - if: "target in [esp32c2]"
+  esp_bsp_devkit:
+    version: "1.0.0"


### PR DESCRIPTION
I wanted to make a multi-zone light controlled, and this multi-on-off-plugin example was really close to what I wanted. I just wanted to control more lights really. This updates makes this example project more of an "out of the box" solution for my project, and I hope others will find the same.
- added support for up to 16 plugs
- updated menuconfig to only display config options for the # of virtual plugs the user has defined
- added a factory reset button with customizable GPIO level, and pin # via menuconfig

default options
<img src="https://github.com/user-attachments/assets/bd50504f-b260-4812-a569-fc1e83240c30" width=500px>
full options
<img src="https://github.com/user-attachments/assets/69e9844f-2c3a-40ae-af24-cbac672b8c8f" width=500px>

