### PR TITLE
components/esp-matter: added features support to power source device …

### DIFF
--- a/components/esp_matter/esp_matter_endpoint.cpp
+++ b/components/esp_matter/esp_matter_endpoint.cpp
@@ -212,7 +212,7 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
         return err;
     }
 
-    cluster_t *cluster = power_source::create(endpoint, &(config->power_source), CLUSTER_FLAG_SERVER, ESP_MATTER_NONE_FEATURE_ID);
+    cluster_t *cluster = power_source::create(endpoint, &(config->power_source), CLUSTER_FLAG_SERVER, config->descriptor.features);
     if (!cluster) {
         return ESP_ERR_INVALID_STATE;
     }


### PR DESCRIPTION
## Description

Based on matter spec 1.3, power source endpoint should support features Wired, Battery, Rechargeable, Replaceable.
This is supported in the cluster creation and in endpoint config through descriptors, but on endpoint creation, descriptor feature are not passed to cluster at creation resulting in ignoring feature attributes.

This pr fix this by passing the features to cluster creation which was an omission.

Although it doesn't introduce breaking changes strictly speaking, if a user did provided feature in descriptor and did not update attributes, it may introduce a change. 


## Related

## Testing

Tested on a matter setup with an Apple homepod device and Apple home app showing low battery level.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes. 
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
