### PR TITLE
fix(thermostat): MinSetpoint­DeadBand should be SignedTemperature (CON-1634)

### DIFF
--- a/components/esp_matter/esp_matter_attribute_bounds.cpp
+++ b/components/esp_matter/esp_matter_attribute_bounds.cpp
@@ -526,8 +526,8 @@ void add_bounds_cb(cluster_t *cluster)
                 break;
             }
             case Thermostat::Attributes::MinSetpointDeadBand::Id: {
-                int16_t min = 0, max = 1270;
-                esp_matter::attribute::add_bounds(current_attribute, esp_matter_int16(min), esp_matter_int16(max));
+                int8_t min = 0, max = 127;
+                esp_matter::attribute::add_bounds(current_attribute, esp_matter_int8(min), esp_matter_int8(max));
                 break;
             }
             case Thermostat::Attributes::ControlSequenceOfOperation::Id: {


### PR DESCRIPTION
## Description

The attribute MinSetpoint­DeadBand in Thermostat cluster should be a SignedTemperature (`int8_t`) value, which is in 0.1°C and constrained to `[0, +127]`.
But the function `esp_matter::cluster::thermostat::add_bounds_cb` erroneously uses TemperatureDifference (`int16_t`) value with wrong constraint `[0, +1270]`.

## Testing

The following snippets should not report the following error:
"Cannot set bounds because of val type mismatch: expected: 7, min: 9, max: 9"

```C++
	esp_matter::cluster_t* thermostat_cluster = /* your cluster */;
	esp_matter::cluster::thermostat::feature::auto_mode::config_t auto_config;
	auto_config.min_setpoint_dead_band = 25;
	esp_matter::cluster::thermostat::feature::auto_mode::add(thermostat_cluster, &auto_config);
```

