### PR TITLE
Fix typo in TVOC cluster namespace (CON-1734)

### DIFF
--- a/components/esp_matter/esp_matter_attribute.cpp
+++ b/components/esp_matter/esp_matter_attribute.cpp
@@ -2744,7 +2744,7 @@ attribute_t *create_level_value(cluster_t *cluster, uint8_t value)
 } /* attribute */
 } /* radon_concentration_measurement */
 
-namespace total_volatile_organic_compound_concentration_measurement {
+namespace total_volatile_organic_compounds_concentration_measurement {
 namespace attribute {
 attribute_t *create_measured_value(cluster_t *cluster, nullable<uint16_t> value)
 {
@@ -2813,7 +2813,7 @@ attribute_t *create_level_value(cluster_t *cluster, uint8_t value)
 }
 
 } /* attribute */
-} /* total_volatile_organic_compound_concentration_measurement */
+} /* total_volatile_organic_compounds_concentration_measurement */
 
 namespace operational_state {
 namespace attribute {


### PR DESCRIPTION
The namespace for TotalVolatileOrganicCompoundsConcentrationMeasurement was missing the trailing ‘s’ in “compounds”, causing unresolved symbol errors when calling create_measurement_medium().

This change corrects the namespace to match the Matter spec, allowing proper linkage.
No functional changes — just a namespace fix to restore expected behavior.