### PR TITLE
Fix parameter order in commissioning callbacks (CON-1874)

### DIFF
--- a/components/esp_matter_controller/commands/esp_matter_controller_pairing_command.cpp
+++ b/components/esp_matter_controller/commands/esp_matter_controller_pairing_command.cpp
@@ -106,7 +106,7 @@ void pairing_command::OnICDStayActiveComplete(ScopedNodeId deviceId, uint32_t pr
 void pairing_command::OnDiscoveredDevice(const Dnssd::CommissionNodeData &nodeData)
 {
     auto &controller_instance = esp_matter::controller::matter_controller_client::get_instance();
-    // Ignore nodes with closed comissioning window
+    // Ignore nodes with closed commissioning window
     VerifyOrReturn(nodeData.commissioningMode != 0);
     const uint16_t port = nodeData.port;
     char buf[Inet::IPAddress::kMaxStringLength];


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

Fixes https://github.com/espressif/esp-matter/issues/1601

This PR changes the order of the arguments to the `ScopedNodeId` creation in the commissioning callbacks.

For example, the original code in the `pairing_command::OnCommissioningSuccess` delegate was

```
m_callbacks.commissioning_success_callback(ScopedNodeId(fabric->GetFabricIndex(), peerId.GetNodeId()));
```

This resulted in the in the ScopedNodeId have its fabric index and node id reversed.

This has been replaced with 

```
m_callbacks.commissioning_success_callback(ScopedNodeId(peerId.GetNodeId(), fabric->GetFabricIndex()));
```

The creation of a ScopedNodeId in `pairing_command::OnCommissioningFailure` has also been updated.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [*] 🚨 This PR does not introduce breaking changes.
- [*] All CI checks (GH Actions) pass.
- [*] Documentation is updated as needed.
- [*] Tests are updated or added as necessary.
- [*] Code is well-commented, especially in complex areas.
- [*] Git history is clean — commits are squashed to the minimum necessary.
