### PR TITLE
Fix MeterIdentification cluster AttributeAccessInterface initialization (CON-1910)

### DIFF
--- a/components/esp_matter/data_model/esp_matter_cluster.cpp
+++ b/components/esp_matter/data_model/esp_matter_cluster.cpp
@@ -4534,6 +4534,9 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         static const auto plugin_server_init_cb = CALL_ONCE(MatterMeterIdentificationPluginServerInitCallback);
         set_plugin_server_init_callback(cluster, plugin_server_init_cb);
+        /* Not a delegate but an Initialization callback */
+        static const auto delegate_init_cb = MeterIdentificationDelegateInitCB;
+        set_delegate_and_init_callback(cluster, delegate_init_cb, nullptr);
         add_function_list(cluster, function_list, function_flags);
 
         /* Attributes managed internally */

--- a/components/esp_matter/data_model/esp_matter_delegate_callbacks.cpp
+++ b/components/esp_matter/data_model/esp_matter_delegate_callbacks.cpp
@@ -54,6 +54,7 @@
 #include <app/clusters/commodity-tariff-server/commodity-tariff-server.h>
 #include <app/clusters/commodity-price-server/commodity-price-server.h>
 #include <app/clusters/electrical-grid-conditions-server/electrical-grid-conditions-server.h>
+#include <app/clusters/meter-identification-server/meter-identification-server.h>
 #include <unordered_map>
 
 using namespace chip::app::Clusters;
@@ -615,6 +616,14 @@ void ElectricalGridConditionsDelegateInitCB(void *delegate, uint16_t endpoint_id
     uint32_t feature_map = get_feature_map_value(endpoint_id, ElectricalGridConditions::Id);
     ElectricalGridConditions::Instance *electrical_grid_conditions_instance = new ElectricalGridConditions::Instance(endpoint_id, *electrical_grid_conditions_delegate, chip::BitMask<ElectricalGridConditions::Feature, uint32_t>(feature_map));
     electrical_grid_conditions_instance->Init();
+}
+
+/* Not a delegate but an Initialization callback */
+void MeterIdentificationDelegateInitCB(void *delegate, uint16_t endpoint_id)
+{
+    uint32_t feature_map = get_feature_map_value(endpoint_id, MeterIdentification::Id);
+    MeterIdentification::Instance *meter_identification_instance = new MeterIdentification::Instance(endpoint_id, chip::BitMask<MeterIdentification::Feature, uint32_t>(feature_map));
+    meter_identification_instance->Init();
 }
 
 } // namespace delegate_cb

--- a/components/esp_matter/data_model/esp_matter_delegate_callbacks.h
+++ b/components/esp_matter/data_model/esp_matter_delegate_callbacks.h
@@ -62,6 +62,7 @@ void PushAvStreamTransportDelegateInitCB(void *delegate, uint16_t endpoint_id);
 void CommodityTariffDelegateInitCB(void *delegate, uint16_t endpoint_id);
 void CommodityPriceDelegateInitCB(void *delegate, uint16_t endpoint_id);
 void ElectricalGridConditionsDelegateInitCB(void *delegate, uint16_t endpoint_id);
+void MeterIdentificationDelegateInitCB(void *delegate, uint16_t endpoint_id);
 } // namespace delegate_cb
 
 } // namespace cluster


### PR DESCRIPTION
## Description

Fixes issue #1636 where `MeterIdentification` cluster attributes return `Attribute is not managed by esp matter data mode`l error.

## Problem

The `MeterIdentification` cluster has a CHIP `AttributeAccessInterface` delegate implementation (`MeterIdentification::Instance`) but it was never instantiated in esp-matter. This caused attribute reads to fail with error code 0x1 (Failure).

## Solution

- Added `MeterIdentificationDelegateInitCB()` callback to instantiate and initialize the `MeterIdentification::Instance` 
- Integrated the delegate initialization in the cluster creation flow
- Added required includes for `meter-identification-server.h`
- Declared the callback in `esp_matter_delegate_callbacks.h`

## Changes

- `components/esp_matter/data_model/esp_matter_cluster.cpp`: Call delegate init callback
- `components/esp_matter/data_model/esp_matter_delegate_callbacks.cpp`: Implement MeterIdentificationDelegateInitCB
- `components/esp_matter/data_model/esp_matter_delegate_callbacks.h`: Declare callback function
- `components/esp_matter/data_model/esp_matter_attribute.cpp`: Keep `ATTRIBUTE_FLAG_MANAGED_INTERNALLY` flags

## Testing

Tested with `all_device_types_app` example creating an electrical_utility_meter endpoint. The `MeterIdentification` cluster attributes (MeterType, PointOfDelivery, MeterSerialNumber) can now be read successfully without errors.

Closes #1636
