### PR TITLE
Fix MeterIdentification MeterType attribute nullable initialization (CON-1909)

### DIFF
--- a/components/esp_matter/data_model/esp_matter_cluster.cpp
+++ b/components/esp_matter/data_model/esp_matter_cluster.cpp
@@ -4538,7 +4538,7 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
 
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-        attribute::create_meter_type(cluster, 0);
+        attribute::create_meter_type(cluster, nullable<uint8_t>(0));
         attribute::create_point_of_delivery(cluster, NULL, 0);
         attribute::create_meter_serial_number(cluster, NULL, 0);
 


### PR DESCRIPTION
## Description

Fixes issue #1639 where the `MeterType` attribute in the MeterIdentification cluster returns `null` instead of the initial value.

## Root Cause

When creating nullable attributes in esp-matter, the creation function expects a `nullable<T>` type parameter. However, a plain integer `0` was passed instead of a properly constructed `nullable<uint8_t>` object.

When passing a plain `0`, the nullable constructor interprets it as an undefined (null) value, not the value 0.

## Solution

Use the proper `nullable<uint8_t>()` constructor when creating the MeterType attribute to ensure correct initialization instead of null value.

## Changes

- Modified `components/esp_matter/data_model/esp_matter_cluster.cpp` line 4543 to use `nullable<uint8_t>()` constructor instead of plain `0`

## Impact

- Fixes MeterType attribute initialization in MeterIdentification cluster
- Ensures nullable attributes are properly initialized with correct types
- Related to PR #1638 but addresses a separate attribute initialization issue

Closes #1639