### PR TITLE
Fix: Correct MinSetpointDeadBand bounds to use int8_t (CON-1986)

### DIFF
--- a/components/esp_matter/data_model/esp_matter_attribute_bounds.cpp
+++ b/components/esp_matter/data_model/esp_matter_attribute_bounds.cpp
@@ -475,8 +475,8 @@ void add_bounds_cb(cluster_t *cluster)
             break;
         }
         case Thermostat::Attributes::MinSetpointDeadBand::Id: {
-            int16_t min = 0, max = 1270;
-            esp_matter::attribute::add_bounds(current_attribute, esp_matter_int16(min), esp_matter_int16(max));
+            int8_t min = 0, max = 127;
+            esp_matter::attribute::add_bounds(current_attribute, esp_matter_int8(min), esp_matter_int8(max));
             break;
         }
         case Thermostat::Attributes::ControlSequenceOfOperation::Id: {


### PR DESCRIPTION
MinSetpointDeadBand is defined as an int8_t, but the bounds were incorrectly created using int16_t. Updated bounds to use int8_t with the correct range (0–127).



## Description

I was receiving this error while prorgramming a thermosatat.
E (2778) data_model: Cannot set bounds because of val type mismatch: expected: 7, min: 9, max: 9

## Related

## Testing

After patch there is no such error.

## Checklist

I unfortunatley do not have these CI tests set up. Should I rather open an issue or create PR to other branch?