### PR TITLE
fix(data_model): silence spurious "Cluster cannot be NULL" error during dynamic endpoint init (CON-1987)

### DIFF
--- a/components/esp_matter/data_model/esp_matter_data_model.cpp
+++ b/components/esp_matter/data_model/esp_matter_data_model.cpp
@@ -222,7 +222,7 @@ static void report_parts_list_change_internal(endpoint_t *endpoint)
         parent_endpoint_id = endpoint::get_parent_endpoint_id(endpoint::get(parent_endpoint_id));
     }
     MatterReportingAttributeChangeCallback(/* endpoint = */ 0, chip::app::Clusters::Descriptor::Id,
-                                           chip::app::Clusters::Descriptor::Attributes::PartsList::Id);
+                                                            chip::app::Clusters::Descriptor::Attributes::PartsList::Id);
 }
 
 esp_err_t disable(endpoint_t *endpoint)
@@ -696,6 +696,9 @@ attribute_t *get(cluster_t *cluster, uint32_t attribute_id)
 attribute_t *get(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id)
 {
     cluster_t *cluster = cluster::get(endpoint_id, cluster_id);
+    if (!cluster) {
+        return nullptr;
+    }
     return get(cluster, attribute_id);
 }
 


### PR DESCRIPTION
## Summary

When using the esp_matter data model (`CONFIG_ESP_MATTER_ENABLE_DATA_MODEL=y`), the error `E data_model: Cluster cannot be NULL.` is logged once per dynamic endpoint during initialization. The device works correctly — the error is benign but confusing.

The error occurs because `attribute::get(endpoint_id, cluster_id, attribute_id)` unconditionally passes the result of `cluster::get()` to `get(cluster_t*, attribute_id)`, which logs at error level when the cluster pointer is NULL. During endpoint registration, CHIP cluster init callbacks read attributes via `emberAfExternalAttributeReadCallback`, which calls this path for clusters that don't exist on the endpoint.

This PR adds a NULL guard in the three-argument overload to return `nullptr` early, silencing the spurious error. The two-argument `get(cluster_t*, attribute_id)` retains its `ESP_LOGE` for direct callers passing NULL (a programming error).

This is consistent with how `command::get(endpoint_id, cluster_id, command_id)` already handles this case (it does the lookup inline with a silent NULL check).

Fixes #1692
Related: #893

## Test plan

- Built and flashed an ESP32-S3 project using esp_matter with dynamic endpoints (`CONFIG_ESP_MATTER_ENABLE_DATA_MODEL=y`)
- Confirmed the `E data_model: Cluster cannot be NULL.` messages no longer appear during boot
- Confirmed Matter initialization proceeds normally and the device operates correctly