### PR TITLE
Allow control of fabric filtering options within commands

### DIFF
--- a/components/esp_matter/esp_matter_client.cpp
+++ b/components/esp_matter/esp_matter_client.cpp
@@ -118,6 +118,9 @@ static void esp_matter_command_client_binding_callback(const chip::app::Clusters
 {
     request_handle_t *req_handle = static_cast<request_handle_t *>(context);
     VerifyOrReturn(req_handle, ESP_LOGE(TAG, "Failed to call the binding callback since command handle is NULL"));
+    ESP_LOGI(TAG, "Binding dispatch: type=%d remote_ep=%u fabric=%u node=0x%llx peer=%s",
+             binding.type, binding.remote, binding.fabricIndex,
+             (unsigned long long)binding.nodeId, peer_device ? "yes" : "no");
     if (binding.type == chip::app::Clusters::Binding::MATTER_UNICAST_BINDING && peer_device) {
         if (client_request_callback) {
             if (req_handle->type == INVOKE_CMD) {
@@ -370,6 +373,12 @@ namespace read {
 esp_err_t send_request(client::peer_device_t *remote_device, AttributePathParams *attr_path, size_t attr_path_size,
                        EventPathParams *event_path, size_t event_path_size, ReadClient::Callback &callback)
 {
+    return send_request(remote_device, attr_path, attr_path_size, event_path, event_path_size, callback, false);
+}
+
+esp_err_t send_request(client::peer_device_t *remote_device, AttributePathParams *attr_path, size_t attr_path_size,
+                       EventPathParams *event_path, size_t event_path_size, ReadClient::Callback &callback, bool fabric_filtered)
+{
     VerifyOrReturnError(remote_device->GetSecureSession().HasValue() && !remote_device->GetSecureSession().Value()->IsGroupSession(), ESP_ERR_INVALID_ARG, ESP_LOGE(TAG, "Invalid Session Type"));
     VerifyOrReturnError((attr_path && attr_path_size != 0) || (event_path && event_path_size != 0),
                         ESP_ERR_INVALID_ARG, ESP_LOGE(TAG, "Invalid attribute path and event path"));
@@ -380,7 +389,7 @@ esp_err_t send_request(client::peer_device_t *remote_device, AttributePathParams
     params.mEventPathParamsListSize = event_path_size;
     params.mpDataVersionFilterList = nullptr;
     params.mDataVersionFilterListSize = 0;
-    params.mIsFabricFiltered = false;
+    params.mIsFabricFiltered = fabric_filtered;
 
     auto client_deleter_callback = chip::Platform::MakeUnique<client_deleter_read_callback>(callback);
     VerifyOrReturnError(client_deleter_callback, ESP_ERR_NO_MEM, ESP_LOGE(TAG, "Failed to allocate memory for client deleter callback"));

--- a/components/esp_matter/esp_matter_client.h
+++ b/components/esp_matter/esp_matter_client.h
@@ -350,6 +350,9 @@ esp_err_t send_group_request(const uint8_t fabric_index, const CommandPathParams
 namespace read {
 esp_err_t send_request(client::peer_device_t *remote_device, AttributePathParams *attr_path, size_t attr_path_size,
                        EventPathParams *event_path, size_t event_path_size, ReadClient::Callback &callback);
+                       
+esp_err_t send_request(client::peer_device_t *remote_device, AttributePathParams *attr_path, size_t attr_path_size,
+                       EventPathParams *event_path, size_t event_path_size, ReadClient::Callback &callback, bool fabric_filtered);
 } // namespace read
 
 /** Attribute write API

--- a/components/esp_matter_controller/commands/esp_matter_controller_read_command.cpp
+++ b/components/esp_matter_controller/commands/esp_matter_controller_read_command.cpp
@@ -41,7 +41,8 @@ void read_command::on_device_connected_fcn(void *context, ExchangeManager &excha
     chip::OperationalDeviceProxy device_proxy(&exchangeMgr, sessionHandle);
     esp_err_t err = interaction::read::send_request(&device_proxy, cmd->m_attr_paths.Get(),
                                                     cmd->m_attr_paths.AllocatedSize(), cmd->m_event_paths.Get(),
-                                                    cmd->m_event_paths.AllocatedSize(), cmd->m_buffered_read_cb);
+                                                    cmd->m_event_paths.AllocatedSize(), cmd->m_buffered_read_cb,
+                                                    cmd->m_fabric_filtered);
     if (err != ESP_OK) {
         chip::Platform::Delete(cmd);
     }

--- a/components/esp_matter_controller/commands/esp_matter_controller_read_command.h
+++ b/components/esp_matter_controller/commands/esp_matter_controller_read_command.h
@@ -52,7 +52,8 @@ public:
                  ScopedMemoryBufferWithSize<EventPathParams> &&event_paths, attribute_report_cb_t attribute_cb,
                  read_done_cb_t read_cb_done, event_report_cb_t event_cb,
                  on_connect_failure_cb_t connect_fail_cb = nullptr,
-                 on_error_callback error_cb = nullptr)
+                 on_error_callback error_cb = nullptr,
+                 bool fabric_filtered = false)
         : m_node_id(node_id)
         , m_buffered_read_cb(*this)
         , m_attr_paths(std::move(attr_paths))
@@ -64,8 +65,10 @@ public:
         , event_data_cb(event_cb)
         , m_on_connect_failure_cb(connect_fail_cb)
         , m_on_error_cb(error_cb)
+        , m_fabric_filtered(fabric_filtered)
     {
     }
+
     /** Constructor for command with single path.
      * @note 0xFFFF could be used as wildcard EndpointId
      * @note 0xFFFFFFFF could be used as wildcard ClusterId/AttributeId/EventId
@@ -74,7 +77,8 @@ public:
                  read_command_type_t command_type, attribute_report_cb_t attribute_cb, read_done_cb_t read_cb_done,
                  event_report_cb_t event_cb,
                  on_connect_failure_cb_t connect_fail_cb = nullptr,
-                 on_error_callback error_cb = nullptr)
+                 on_error_callback error_cb = nullptr,
+                 bool fabric_filtered = false)
         : m_node_id(node_id)
         , m_buffered_read_cb(*this)
         , on_device_connected_cb(on_device_connected_fcn, this)
@@ -84,6 +88,7 @@ public:
         , event_data_cb(event_cb)
         , m_on_connect_failure_cb(connect_fail_cb)
         , m_on_error_cb(error_cb)
+        , m_fabric_filtered(fabric_filtered)
     {
         if (command_type == READ_ATTRIBUTE) {
             m_attr_paths.Alloc(1);
@@ -135,6 +140,8 @@ private:
 
     on_connect_failure_cb_t m_on_connect_failure_cb;
     on_error_callback m_on_error_cb;
+
+    bool m_fabric_filtered;
 };
 
 /** Send read command with multiple attribute paths


### PR DESCRIPTION
## Description

This PR adds a new optional parameter to `esp_matter::controller::read_command` that allows the caller to control `FabricFiltered`. 

FabricFiltered is specified in 8.4.2.1 of the Core Specification.

The value is currently hardcoded to `false` in the `send_request` method.

```
params.mIsFabricFiltered = false;
```

By not allowing control of this parameter, the application code has to work harder to filter out unrelated fabrics.

This PR leaves the default value to `false`, thought I believe a default of `true` makes more sense.

## Testing

I have tested this is my application firmware. When reading the access control list, before the change

```
I (44153) chip[TOO]: Endpoint: 0 Cluster: 0x0000_001F Attribute 0x0000_0000 DataVersion: 2289394094
I (44153) chip[TOO]:   ACL: 4 entries
I (44153) chip[TOO]:     [1]: {
I (44163) chip[TOO]:       Privilege: 0
I (44173) chip[TOO]:       AuthMode: 0
I (44173) chip[TOO]:       Subjects: null
I (44173) chip[TOO]:       Targets: null
I (44183) chip[TOO]:       FabricIndex: 1
I (44183) chip[TOO]:      }
I (44183) chip[TOO]:     [2]: {
I (44183) chip[TOO]:       Privilege: 0
I (44183) chip[TOO]:       AuthMode: 0
I (44193) chip[TOO]:       Subjects: null
I (44193) chip[TOO]:       Targets: null
I (44203) chip[TOO]:       FabricIndex: 1
I (44203) chip[TOO]:      }
I (44213) chip[TOO]:     [3]: {
I (44213) chip[TOO]:       Privilege: 5
I (44213) chip[TOO]:       AuthMode: 2
I (44213) chip[TOO]:       Subjects: 1 entries
I (44223) chip[TOO]:         [1]: 112233
I (44223) chip[TOO]:       Targets: null
I (44223) chip[TOO]:       FabricIndex: 2
I (44223) chip[TOO]:      }
I (44233) chip[TOO]:     [4]: {
I (44243) chip[TOO]:       Privilege: 3
I (44243) chip[TOO]:       AuthMode: 3
I (44243) chip[TOO]:       Subjects: 1 entries
I (44243) chip[TOO]:         [1]: 4
I (44253) chip[TOO]:       Targets: null
I (44253) chip[TOO]:       FabricIndex: 2
I (44253) chip[TOO]:      }
I (44253) read_command: read done
```
Passing `true`, returns only the values I'd expect.

```
I (145933) chip[TOO]: Endpoint: 0 Cluster: 0x0000_001F Attribute 0x0000_0000 DataVersion: 2289394094
I (145943) chip[TOO]:   ACL: 2 entries
I (145943) chip[TOO]:     [1]: {
I (145953) chip[TOO]:       Privilege: 5
I (145953) chip[TOO]:       AuthMode: 2
I (145953) chip[TOO]:       Subjects: 1 entries
I (145953) chip[TOO]:         [1]: 112233
I (145963) chip[TOO]:       Targets: null
I (145963) chip[TOO]:       FabricIndex: 2
I (145973) chip[TOO]:      }
I (145973) chip[TOO]:     [2]: {
I (145973) chip[TOO]:       Privilege: 3
I (145983) chip[TOO]:       AuthMode: 3
I (145983) chip[TOO]:       Subjects: 1 entries
I (145983) chip[TOO]:         [1]: 4
I (145983) chip[TOO]:       Targets: null
I (145993) chip[TOO]:       FabricIndex: 2
I (145993) chip[TOO]:      }
I (146003) read_command: read done
```

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
