### PR TITLE
temperature_measurement: add FindClusterOnEndpoint and SetMeasuredVal…

### DIFF
--- a/components/esp_matter/data_model_provider/clusters/temperature_measurement/integration.cpp
+++ b/components/esp_matter/data_model_provider/clusters/temperature_measurement/integration.cpp
@@ -35,6 +35,26 @@ namespace {
 std::unordered_map<EndpointId, LazyRegisteredServerCluster<TemperatureMeasurementCluster>> gServers;
 } // namespace
 
+namespace chip::app::Clusters::TemperatureMeasurement {
+
+TemperatureMeasurementCluster * FindClusterOnEndpoint(EndpointId endpointId)
+{
+    auto it = gServers.find(endpointId);
+    if (it == gServers.end() || !it->second.IsConstructed()) {
+        return nullptr;
+    }
+    return &it->second.Cluster();
+}
+
+CHIP_ERROR SetMeasuredValue(EndpointId endpointId, DataModel::Nullable<int16_t> measuredValue)
+{
+    auto * cluster = FindClusterOnEndpoint(endpointId);
+    VerifyOrReturnError(cluster != nullptr, CHIP_ERROR_NOT_FOUND);
+    return cluster->SetMeasuredValue(measuredValue);
+}
+
+} // namespace chip::app::Clusters::TemperatureMeasurement
+
 void ESPMatterTemperatureMeasurementClusterServerInitCallback(EndpointId endpointId)
 {
     VerifyOrReturn(cluster::get(endpointId, TemperatureMeasurement::Id) != nullptr,


### PR DESCRIPTION
temperature_measurement: add FindClusterOnEndpoint and SetMeasuredValue wrappers

The flow_measurement and relative_humidity_measurement integration.cpp files provide namespace-level FindClusterOnEndpoint() and SetMeasuredValue() wrappers so application code can write to codegen cluster storage directly (bypassing esp-matter attribute::update, which desyncs for non-writable attributes on codegen clusters — esp-matter storage vs codegen mMeasuredValue).

temperature_measurement was missing these wrappers. Add them following the flow_measurement pattern so apps using TemperatureMeasurement can use SetMeasuredValue() the same way.

Refs: pattern from clusters/flow_measurement/integration.cpp

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

`temperature_measurement` was the only measurement cluster in
`components/esp_matter/data_model_provider/clusters/` without
namespace-level `FindClusterOnEndpoint()` and `SetMeasuredValue()`
wrappers in its `integration.cpp`. `flow_measurement` and
`relative_humidity_measurement` already provide them.

For codegen-backed clusters, writing a non-writable attribute via
`esp_matter::attribute::update()` desyncs the two stores: it writes
the esp-matter storage, but `ReadAttribute` reads from the codegen
`mMeasuredValue`. Application code that wants to update
`MeasuredValue` must call the codegen `SetMeasuredValue()` method on
the cluster instance.

The cluster instance is looked up via `FindClusterOnEndpoint(endpointId)`,
which exists in `CodegenIntegration.h` — but the matching
`CodegenIntegration.cpp` is excluded from the esp-matter build by
`CMakeLists.txt` (`EXCLUDE_SRCS_LIST` for `Codegen*.cpp`). The other
measurement clusters solve this by re-declaring the wrapper in
`integration.cpp` (the file actually compiled).

Without this wrapper, apps that call
`TemperatureMeasurement::SetMeasuredValue()` get a link error.

### Changes

- `components/esp_matter/data_model_provider/clusters/temperature_measurement/integration.cpp`
  - Add `FindClusterOnEndpoint(EndpointId)` (matches `flow_measurement` pattern)
  - Add `SetMeasuredValue(EndpointId, DataModel::Nullable<int16_t>)` convenience wrapper

```cpp
namespace chip::app::Clusters::TemperatureMeasurement {

TemperatureMeasurementCluster * FindClusterOnEndpoint(EndpointId endpointId)
{
    auto it = gServers.find(endpointId);
    if (it == gServers.end() || !it->second.IsConstructed()) {
        return nullptr;
    }
    return &it->second.Cluster();
}

CHIP_ERROR SetMeasuredValue(EndpointId endpointId, DataModel::Nullable<int16_t> measuredValue)
{
    auto * cluster = FindClusterOnEndpoint(endpointId);
    VerifyOrReturnError(cluster != nullptr, CHIP_ERROR_NOT_FOUND);
    return cluster->SetMeasuredValue(measuredValue);
}

} // namespace chip::app::Clusters::TemperatureMeasurement
```

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

- Pattern source: `components/esp_matter/data_model_provider/clusters/flow_measurement/integration.cpp`
- Pattern source: `components/esp_matter/data_model_provider/clusters/relative_humidity_measurement/integration.cpp`
- Build exclusion: `components/esp_matter/data_model_provider/CMakeLists.txt` (`EXCLUDE_SRCS_LIST` for `Codegen*.cpp`)

## Testing

- Pattern matches existing `flow_measurement/integration.cpp` and
  `relative_humidity_measurement/integration.cpp` exactly — no behavior
  change for apps that do not call the new wrappers.
- Build verified with an out-of-tree ESP-IDF + esp-matter example that calls
  `TemperatureMeasurement::SetMeasuredValue()`; without this wrapper the link
  step fails with an undefined reference to
  `FindClusterOnEndpoint(EndpointId)`, with it the link succeeds and the
  attribute reads back the value set via the codegen path.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.