### PR TITLE
feat(data_model): add Network Infrastructure Manager device type to legacy data model

### DIFF
--- a/components/esp_matter/data_model/legacy/esp_matter_endpoint.cpp
+++ b/components/esp_matter/data_model/legacy/esp_matter_endpoint.cpp
@@ -1769,6 +1769,37 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
 
 } /* thread_border_router */
 
+namespace network_infrastructure_manager {
+
+uint32_t get_device_type_id()
+{
+    return ESP_MATTER_NETWORK_INFRASTRUCTURE_MANAGER_DEVICE_TYPE_ID;
+}
+
+uint8_t get_device_type_version()
+{
+    return ESP_MATTER_NETWORK_INFRASTRUCTURE_MANAGER_DEVICE_TYPE_VERSION;
+}
+
+endpoint_t *create(node_t *node, config_t *config, uint8_t flags, void *priv_data)
+{
+    return common::create<config_t>(node, config, flags, priv_data, add);
+}
+
+esp_err_t add(endpoint_t *endpoint, config_t *config)
+{
+    esp_err_t err = add_device_type(endpoint, get_device_type_id(), get_device_type_version());
+    VerifyOrReturnError(err == ESP_OK, err);
+
+    thread_network_diagnostics::create(endpoint, &(config->thread_network_diagnostics), CLUSTER_FLAG_SERVER);
+    wifi_network_management::create(endpoint, &(config->wifi_network_management), CLUSTER_FLAG_SERVER);
+    thread_border_router_management::create(endpoint, &(config->thread_border_router_management), CLUSTER_FLAG_SERVER);
+    thread_network_directory::create(endpoint, &(config->thread_network_directory), CLUSTER_FLAG_SERVER);
+    return ESP_OK;
+}
+
+} /* network_infrastructure_manager */
+
 #ifndef CONFIG_CUSTOM_NETWORK_CONFIG
 namespace secondary_network_interface {
 uint32_t get_device_type_id()

--- a/components/esp_matter/data_model/legacy/esp_matter_endpoint_impl.h
+++ b/components/esp_matter/data_model/legacy/esp_matter_endpoint_impl.h
@@ -146,6 +146,8 @@
 
 #define ESP_MATTER_THREAD_BORDER_ROUTER_DEVICE_TYPE_ID 0x0091
 #define ESP_MATTER_THREAD_BORDER_ROUTER_DEVICE_TYPE_VERSION 2
+#define ESP_MATTER_NETWORK_INFRASTRUCTURE_MANAGER_DEVICE_TYPE_ID 0x0090
+#define ESP_MATTER_NETWORK_INFRASTRUCTURE_MANAGER_DEVICE_TYPE_VERSION 2
 #define ESP_MATTER_HEAT_PUMP_DEVICE_TYPE_ID 0x0309
 #define ESP_MATTER_HEAT_PUMP_DEVICE_TYPE_VERSION 1
 #define ESP_MATTER_THERMOSTAT_CONTROLLER_DEVICE_TYPE_ID 0x030A
@@ -1013,6 +1015,21 @@ uint8_t get_device_type_version();
 endpoint_t *create(node_t *node, config_t *config, uint8_t flags, void *priv_data);
 esp_err_t add(endpoint_t *endpoint, config_t *config);
 } /* thread_border_router */
+
+namespace network_infrastructure_manager {
+typedef struct config {
+    cluster::descriptor::config_t descriptor;
+    cluster::thread_network_diagnostics::config_t thread_network_diagnostics;
+    cluster::wifi_network_management::config_t wifi_network_management;
+    cluster::thread_border_router_management::config_t thread_border_router_management;
+    cluster::thread_network_directory::config_t thread_network_directory;
+} config_t;
+
+uint32_t get_device_type_id();
+uint8_t get_device_type_version();
+endpoint_t *create(node_t *node, config_t *config, uint8_t flags, void *priv_data);
+esp_err_t add(endpoint_t *endpoint, config_t *config);
+} /* network_infrastructure_manager */
 
 #ifndef CONFIG_CUSTOM_NETWORK_CONFIG
 namespace secondary_network_interface {

--- a/examples/thread_border_router/README.md
+++ b/examples/thread_border_router/README.md
@@ -40,6 +40,18 @@ $ idf.py set-target esp32s3
 $ idf.py build
 ```
 
+### 1.4 Device Type: Thread Border Router vs. Network Infrastructure Manager
+
+By default, this example advertises itself as a **Thread Border Router** Matter device type, exposing `ThreadNetworkDiagnostics` (when Thread is enabled) and `ThreadBorderRouterManagement`.
+
+It can instead advertise as a **Network Infrastructure Manager** device type, a superset which additionally exposes `WiFiNetworkManagement` and `ThreadNetworkDirectory` on the same endpoint. Enable `CONFIG_ENABLE_NETWORK_INFRASTRUCTURE_MANAGER` via:
+
+```
+$ idf.py menuconfig
+```
+
+under **Thread Border Router Example**, then build as usual.
+
 ## 2. Post Commissioning Setup
 
 After commissioning the Border Router with chip-tool, you can set up the Thread network with ThreadBorderRouterManagement cluster.

--- a/examples/thread_border_router/main/Kconfig.projbuild
+++ b/examples/thread_border_router/main/Kconfig.projbuild
@@ -1,0 +1,16 @@
+menu "Thread Border Router Example"
+
+    config ENABLE_NETWORK_INFRASTRUCTURE_MANAGER
+        bool "Use the Network Infrastructure Manager device type instead of Thread Border Router"
+        default n
+        help
+            The "Network Infrastructure Manager" (NIM) Matter device type is a superset of
+            "Thread Border Router": it exposes the same ThreadBorderRouterManagement cluster
+            (and ThreadNetworkDiagnostics, if Thread is enabled), plus WiFiNetworkManagement
+            and ThreadNetworkDirectory.
+
+            Enable this to advertise the endpoint as a Network Infrastructure Manager instead
+            of a plain Thread Border Router. Left disabled by default to preserve this
+            example's existing behavior.
+
+endmenu

--- a/examples/thread_border_router/main/app_main.cpp
+++ b/examples/thread_border_router/main/app_main.cpp
@@ -86,9 +86,15 @@ extern "C" void app_main()
         ESP_LOGE(TAG, "Failed to create thread_border_router delegate");
         return;
     }
+#if CONFIG_ENABLE_NETWORK_INFRASTRUCTURE_MANAGER
+    network_infrastructure_manager::config_t tbr_config;
+    tbr_config.thread_border_router_management.delegate = delegate;
+    endpoint_t *tbr_endpoint = network_infrastructure_manager::create(node, &tbr_config, ENDPOINT_FLAG_NONE, NULL);
+#else
     thread_border_router::config_t tbr_config;
     tbr_config.thread_border_router_management.delegate = delegate;
     endpoint_t *tbr_endpoint = thread_border_router::create(node, &tbr_config, ENDPOINT_FLAG_NONE, NULL);
+#endif
     if (!node || !tbr_endpoint) {
         ESP_LOGE(TAG, "Failed to create data model");
         return;

--- a/examples/thread_border_router/main/app_main.cpp
+++ b/examples/thread_border_router/main/app_main.cpp
@@ -32,6 +32,12 @@
 #include <credentials/FabricTable.h>
 #include <platform/KvsPersistentStorageDelegate.h>
 
+#if CONFIG_ENABLE_NETWORK_INFRASTRUCTURE_MANAGER
+#include <app/clusters/thread-network-directory-server/CodegenIntegration.h>
+#include <app/clusters/wifi-network-management-server/CodegenIntegration.h>
+#include <optional>
+#endif
+
 static const char *TAG = "app_main";
 
 using namespace esp_matter;
@@ -39,6 +45,30 @@ using namespace esp_matter::attribute;
 using namespace esp_matter::endpoint;
 using namespace chip::app::Clusters;
 using chip::app::Clusters::ThreadBorderRouterManagement::GenericOpenThreadBorderRouterDelegate;
+
+#if CONFIG_ENABLE_NETWORK_INFRASTRUCTURE_MANAGER
+// WiFiNetworkManagement and ThreadNetworkDirectory (unlike ThreadBorderRouterManagement) are not
+// auto-instantiated by the ZAP/attribute-storage framework - the application must instantiate and
+// register them itself. This mirrors the pattern documented in
+// <app/clusters/wifi-network-management-server/CodegenIntegration.h> and
+// <app/clusters/thread-network-directory-server/CodegenIntegration.h>.
+//
+// TODO: WiFiNetworkManagementServer::SetNetworkCredentials() still needs to be called with the
+// actual Wi-Fi STA SSID/passphrase once available (e.g. after Network Commissioning completes) -
+// left as a follow-up since this example does not otherwise expose that state.
+static std::optional<WiFiNetworkManagementServer> gWiFiNetworkManagementServer;
+static std::optional<DefaultThreadNetworkDirectoryServer> gThreadNetworkDirectoryServer;
+
+void emberAfWiFiNetworkManagementClusterInitCallback(chip::EndpointId endpoint)
+{
+    SuccessOrDie(gWiFiNetworkManagementServer.emplace(endpoint).Init());
+}
+
+void emberAfThreadNetworkDirectoryClusterInitCallback(chip::EndpointId endpoint)
+{
+    SuccessOrDie(gThreadNetworkDirectoryServer.emplace(endpoint).Init());
+}
+#endif // CONFIG_ENABLE_NETWORK_INFRASTRUCTURE_MANAGER
 
 static void app_event_cb(const ChipDeviceEvent *event, intptr_t arg)
 {


### PR DESCRIPTION
## Description

Adds the **Network Infrastructure Manager (NIM)** Matter device type (`0x0090`) to the **legacy** data model, and an opt-in Kconfig option in `examples/thread_border_router` to use it instead of the plain "Thread Border Router" device type.

NIM is a superset of what the example already exposes: same `ThreadBorderRouterManagement` cluster, plus `WiFiNetworkManagement` and `ThreadNetworkDirectory` (and `ThreadNetworkDiagnostics` when Thread is enabled, same as today). All four clusters already existed in the legacy data model (`cluster::wifi_network_management`, `cluster::thread_network_directory`, `cluster::thread_border_router_management`, `cluster::thread_network_diagnostics`) — this only adds the device-type-level composition that was missing, mirroring the existing `network_infrastructure_manager_device.cpp` under the generated/experimental data model, but without requiring `CONFIG_ESP_MATTER_ENABLE_GENERATED_DATA_MODEL` (which disables all legacy data model code).

### Changes

- `components/esp_matter/data_model/legacy/esp_matter_endpoint_impl.h`: device type ID/version defines + `network_infrastructure_manager` namespace declarations (`config_t`, prototypes).
- `components/esp_matter/data_model/legacy/esp_matter_endpoint.cpp`: `network_infrastructure_manager::create()`/`add()` implementation.
- `examples/thread_border_router/main/Kconfig.projbuild` (new): `CONFIG_ENABLE_NETWORK_INFRASTRUCTURE_MANAGER`, default `n` — preserves the example's current default behavior.
- `examples/thread_border_router/main/app_main.cpp`:
  - conditionally instantiate `network_infrastructure_manager::create()` instead of `thread_border_router::create()` when the option above is enabled.
  - registers `WiFiNetworkManagementServer` / `DefaultThreadNetworkDirectoryServer` via `emberAf*ClusterInitCallback`. **Important**: unlike `ThreadBorderRouterManagement`, these two clusters are not auto-instantiated by the ZAP/attribute-storage framework in the pinned connectedhomeip commit (`efefc94fee`) — the application has to instantiate and register them manually, per the pattern documented directly in `wifi-network-management-server/CodegenIntegration.h` and `thread-network-directory-server/CodegenIntegration.h`. Without this second commit, the two clusters would compile but silently not function (their legacy `MatterXXXPluginServerInitCallback` hooks are empty stubs in this CHIP commit — the real registration path is a newer `DefaultServerCluster`/codegen mechanism the legacy data model doesn't otherwise trigger).

### Known gap

`WiFiNetworkManagementServer::SetNetworkCredentials()` still needs to be called with the actual Wi-Fi STA SSID/passphrase once available (e.g. after Network Commissioning completes) for the cluster to report real data — left as a `TODO` in code, since this example doesn't otherwise expose that state at the call site.

### Why draft

I don't have a local `connectedhomeip`/CHIP build toolchain available in the environment I wrote this in, so **this has not been build- or hardware-verified**. In particular:
- Whether ARL (Access Restriction List, behind `CHIP_CONFIG_USE_ACCESS_RESTRICTIONS` in the Access Control cluster) is functional end-to-end on this path is unverified — that code path already exists in legacy independently of this PR, I haven't added anything for it here.
- The `emberAf*ClusterInitCallback` wiring follows the exact pattern documented in the CHIP headers themselves, but hasn't been compiled.

Opening as draft for early feedback on the approach — see discussion in #1821.

Closes #1821 (pending confirmation this is the right direction).