### PR TITLE
Enable door lock access schedules

### DIFF
--- a/examples/door_lock/README.md
+++ b/examples/door_lock/README.md
@@ -12,7 +12,13 @@ No additional setup is required.
 
 No additional setup is required.
 
-## 3. Aliro over NFC Feature
+## 3. Access Schedules
+
+The Week Day, Year Day, and Holiday access-schedule features support persistent create, read, and clear operations.
+
+Schedules are not yet enforced when validating a PIN credential. Configuring a schedule therefore does not currently restrict access.
+
+## 4. Aliro over NFC Feature
 
 ### Hardware Required
 
@@ -39,7 +45,7 @@ After commissioning with the Apple Home app, the Home app automatically adds a k
 | :----------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------: |
 | <img src="./img/home_key_add.jpeg" alt="Home Key added to Apple Wallet" width="300"> | <img src="./img/unlock_page.jpeg" alt="Unlocking the door with Apple Home" width="300"> |
 
-## 4. Local Controls and Status
+## 5. Local Controls and Status
 
 Press the boot button (front button on M5Stack Nano) to toggle the lock state. The RGB LED indicates the current state:
 
@@ -48,7 +54,7 @@ Press the boot button (front button on M5Stack Nano) to toggle the lock state. T
 - Amber: locking or unlocking
 - Off: unknown state
 
-## 5. Diagnostic Console
+## 6. Diagnostic Console
 
 The door-lock debug command is available under `matter esp dl`:
 

--- a/examples/door_lock/main/app_main.cpp
+++ b/examples/door_lock/main/app_main.cpp
@@ -169,6 +169,11 @@ extern "C" void app_main()
     cluster::door_lock::feature::user::config_t user_config;
     user_config.number_of_total_user_supported = DoorLockCapabilities::kUsers;
     user_config.number_of_credentials_supported_per_user = DoorLockCapabilities::kCredentialsPerUser;
+    cluster::door_lock::feature::year_day_access_schedules::config_t year_day_access_schedules_config;
+    year_day_access_schedules_config.number_of_year_day_schedules_supported_per_user =
+        DoorLockCapabilities::kYeardaySchedulesPerUser;
+    cluster::door_lock::feature::holiday_schedules::config_t holiday_schedules_config;
+    holiday_schedules_config.number_of_holiday_schedules_supported = DoorLockCapabilities::kHolidaySchedules;
     // endpoint handles can be used to add/modify clusters.
     endpoint_t *endpoint = door_lock::create(node, &door_lock_config, ENDPOINT_FLAG_NONE, NULL);
     ABORT_APP_ON_FAILURE(endpoint != nullptr, ESP_LOGE(TAG, "Failed to create door lock endpoint"));
@@ -176,6 +181,9 @@ extern "C" void app_main()
     cluster::door_lock::feature::credential_over_the_air_access::add(door_lock_cluster, &cota_config);
     cluster::door_lock::feature::pin_credential::add(door_lock_cluster, &pin_credential_config);
     cluster::door_lock::feature::user::add(door_lock_cluster, &user_config);
+    cluster::door_lock::feature::weekday_access_schedules::add(door_lock_cluster);
+    cluster::door_lock::feature::year_day_access_schedules::add(door_lock_cluster, &year_day_access_schedules_config);
+    cluster::door_lock::feature::holiday_schedules::add(door_lock_cluster, &holiday_schedules_config);
 #ifdef CONFIG_ENABLE_ALIRO_OVER_NFC
     cluster::door_lock::feature::aliro_provisioning::add(door_lock_cluster);
 #endif

--- a/examples/door_lock/main/lock/door_lock_callbacks.cpp
+++ b/examples/door_lock/main/lock/door_lock_callbacks.cpp
@@ -77,6 +77,13 @@ bool ReadCredentialSlotLimits(DoorLockServer  &server, EndpointId endpoint,
     return true;
 }
 
+bool ReadScheduleLimits(DoorLockServer  &server, EndpointId endpoint, DoorLockStorage::Limits  &limits)
+{
+    return server.GetNumberOfWeekDaySchedulesPerUserSupported(endpoint, limits.numberOfWeekdaySchedulesPerUser) &&
+           server.GetNumberOfYearDaySchedulesPerUserSupported(endpoint, limits.numberOfYeardaySchedulesPerUser) &&
+           server.GetNumberOfHolidaySchedulesSupported(endpoint, limits.numberOfHolidaySchedules);
+}
+
 void HandleBoltStateChange(BoltLockManager::State state, BoltLockManager::OperationSource source)
 {
     DlLockState lockState = DlLockState::kNotFullyLocked;
@@ -124,6 +131,7 @@ void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
     VerifyOrDie(server.GetNumberOfUserSupported(endpoint, limits.numberOfUsers));
     VerifyOrDie(server.GetNumberOfCredentialsSupportedPerUser(endpoint, limits.numberOfCredentialsPerUser));
     VerifyOrDie(ReadCredentialSlotLimits(server, endpoint, limits));
+    VerifyOrDie(ReadScheduleLimits(server, endpoint, limits));
     DoorLockStorage::Config storageConfig{ endpoint, limits, Server::GetInstance().GetPersistentStorage() };
     CHIP_ERROR err = DoorLockStorage::Instance().Init(storageConfig);
     if (err != CHIP_NO_ERROR) {
@@ -198,6 +206,47 @@ bool emberAfPluginDoorLockSetUser(EndpointId endpoint, uint16_t userIndex, Fabri
 {
     return DoorLockStorage::Instance().SetUser(userIndex, creator, modifier, userName, uniqueId, userStatus, userType,
                                                credentialRule, credentials, totalCredentials);
+}
+
+DlStatus emberAfPluginDoorLockGetSchedule(EndpointId endpoint, uint8_t scheduleIndex, uint16_t userIndex,
+                                          EmberAfPluginDoorLockWeekDaySchedule  &schedule)
+{
+    return DoorLockStorage::Instance().GetWeekdaySchedule(scheduleIndex, userIndex, schedule);
+}
+
+DlStatus emberAfPluginDoorLockGetSchedule(EndpointId endpoint, uint8_t scheduleIndex, uint16_t userIndex,
+                                          EmberAfPluginDoorLockYearDaySchedule  &schedule)
+{
+    return DoorLockStorage::Instance().GetYeardaySchedule(scheduleIndex, userIndex, schedule);
+}
+
+DlStatus emberAfPluginDoorLockGetSchedule(EndpointId endpoint, uint8_t scheduleIndex,
+                                          EmberAfPluginDoorLockHolidaySchedule  &schedule)
+{
+    return DoorLockStorage::Instance().GetHolidaySchedule(scheduleIndex, schedule);
+}
+
+DlStatus emberAfPluginDoorLockSetSchedule(EndpointId endpoint, uint8_t scheduleIndex, uint16_t userIndex,
+                                          DlScheduleStatus status, DaysMaskMap daysMask, uint8_t startHour,
+                                          uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
+{
+    return DoorLockStorage::Instance().SetWeekdaySchedule(scheduleIndex, userIndex, status, daysMask, startHour,
+                                                          startMinute, endHour, endMinute);
+}
+
+DlStatus emberAfPluginDoorLockSetSchedule(EndpointId endpoint, uint8_t scheduleIndex, uint16_t userIndex,
+                                          DlScheduleStatus status, uint32_t localStartTime, uint32_t localEndTime)
+{
+    return DoorLockStorage::Instance().SetYeardaySchedule(scheduleIndex, userIndex, status, localStartTime,
+                                                          localEndTime);
+}
+
+DlStatus emberAfPluginDoorLockSetSchedule(EndpointId endpoint, uint8_t scheduleIndex, DlScheduleStatus status,
+                                          uint32_t localStartTime, uint32_t localEndTime,
+                                          OperatingModeEnum operatingMode)
+{
+    return DoorLockStorage::Instance().SetHolidaySchedule(scheduleIndex, status, localStartTime, localEndTime,
+                                                          operatingMode);
 }
 
 void emberAfPluginDoorLockOnAutoRelock(EndpointId endpoint)

--- a/examples/door_lock/main/lock/door_lock_capabilities.h
+++ b/examples/door_lock/main/lock/door_lock_capabilities.h
@@ -27,6 +27,10 @@ constexpr uint16_t kUsers = 6;
 constexpr uint8_t kCredentialsPerUser = 4;
 // Total number of PIN credential slots, shared by all users.
 constexpr uint16_t kPinCredentialSlots = 6;
+// Week Day remains at one until the SDK exposes its count as a feature configuration.
+constexpr uint8_t kWeekdaySchedulesPerUser = 1;
+constexpr uint8_t kYeardaySchedulesPerUser = 1;
+constexpr uint8_t kHolidaySchedules = 1;
 
 // Total number of Aliro credential issuer key slots.
 constexpr uint16_t kAliroCredentialIssuerKeySlots = 2;

--- a/examples/door_lock/main/lock/door_lock_storage.cpp
+++ b/examples/door_lock/main/lock/door_lock_storage.cpp
@@ -58,6 +58,12 @@ CHIP_ERROR DoorLockStorage::Init(const Config  &config)
     VerifyOrReturnError(limits.numberOfCredentialsPerUser > 0 &&
                         limits.numberOfCredentialsPerUser <= kMaxCredentialsPerUser,
                         CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(limits.numberOfWeekdaySchedulesPerUser <= kMaxSchedulesPerUser,
+                        CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(limits.numberOfYeardaySchedulesPerUser <= kMaxSchedulesPerUser,
+                        CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(limits.numberOfHolidaySchedules <= kMaxHolidaySchedules,
+                        CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(limits.credentialSlotsByType[to_underlying(CredentialTypeEnum::kProgrammingPIN)] == 1,
                         CHIP_ERROR_INVALID_ARGUMENT);
     for (uint16_t slotCount : limits.credentialSlotsByType) {
@@ -69,6 +75,14 @@ CHIP_ERROR DoorLockStorage::Init(const Config  &config)
     mLimits = limits;
     std::fill_n(mUsers, kMaxUsers, UserRecord());
     std::fill_n(mCredentials, kCredentialSlotCount, CredentialRecord());
+    for (size_t userIndex = 0; userIndex < kMaxUsers; ++userIndex) {
+        std::fill_n(mWeekdaySchedules[userIndex], kMaxSchedulesPerUser,
+                    ScheduleRecord<EmberAfPluginDoorLockWeekDaySchedule>());
+        std::fill_n(mYeardaySchedules[userIndex], kMaxSchedulesPerUser,
+                    ScheduleRecord<EmberAfPluginDoorLockYearDaySchedule>());
+    }
+    std::fill_n(mHolidaySchedules, kMaxHolidaySchedules,
+                ScheduleRecord<EmberAfPluginDoorLockHolidaySchedule>());
     for (size_t userIndex = 0; userIndex < kMaxUsers; ++userIndex) {
         std::fill_n(mUserCredentialViews[userIndex], kMaxCredentialsPerUser, CredentialStruct());
     }
@@ -138,6 +152,26 @@ CHIP_ERROR DoorLockStorage::LoadRecords()
                 return CHIP_ERROR_INVALID_ARGUMENT;
             }
         }
+    }
+
+    for (uint16_t userIndex = 1; userIndex <= mLimits.numberOfUsers; ++userIndex) {
+        for (uint8_t scheduleIndex = 1; scheduleIndex <= mLimits.numberOfWeekdaySchedulesPerUser; ++scheduleIndex) {
+            VerifyOrReturnError(MakeScheduleKey("ws", scheduleIndex, userIndex, key, sizeof(key)), CHIP_ERROR_INVALID_ARGUMENT);
+            bool found = false;
+            ReturnErrorOnFailure(ReadRecord(key, &mWeekdaySchedules[userIndex - 1][scheduleIndex - 1],
+                                            sizeof(mWeekdaySchedules[0][0]), found));
+        }
+        for (uint8_t scheduleIndex = 1; scheduleIndex <= mLimits.numberOfYeardaySchedulesPerUser; ++scheduleIndex) {
+            VerifyOrReturnError(MakeScheduleKey("ys", scheduleIndex, userIndex, key, sizeof(key)), CHIP_ERROR_INVALID_ARGUMENT);
+            bool found = false;
+            ReturnErrorOnFailure(ReadRecord(key, &mYeardaySchedules[userIndex - 1][scheduleIndex - 1],
+                                            sizeof(mYeardaySchedules[0][0]), found));
+        }
+    }
+    for (uint8_t scheduleIndex = 1; scheduleIndex <= mLimits.numberOfHolidaySchedules; ++scheduleIndex) {
+        VerifyOrReturnError(MakeScheduleKey("hs", scheduleIndex, 0, key, sizeof(key)), CHIP_ERROR_INVALID_ARGUMENT);
+        bool found = false;
+        ReturnErrorOnFailure(ReadRecord(key, &mHolidaySchedules[scheduleIndex - 1], sizeof(mHolidaySchedules[0]), found));
     }
 
     return CHIP_NO_ERROR;
@@ -375,6 +409,106 @@ bool DoorLockStorage::SetCredential(uint16_t credentialIndex, FabricIndex creato
     return true;
 }
 
+DlStatus DoorLockStorage::GetWeekdaySchedule(uint8_t scheduleIndex, uint16_t userIndex,
+                                             EmberAfPluginDoorLockWeekDaySchedule  &schedule) const
+{
+    VerifyOrReturnValue(mInitialized && scheduleIndex > 0 && userIndex > 0 &&
+                        scheduleIndex <= mLimits.numberOfWeekdaySchedulesPerUser &&
+                        userIndex <= mLimits.numberOfUsers,
+                        DlStatus::kFailure);
+    const auto  &record = mWeekdaySchedules[userIndex - 1][scheduleIndex - 1];
+    VerifyOrReturnValue(record.status != DlScheduleStatus::kAvailable, DlStatus::kNotFound);
+    schedule = record.schedule;
+    return DlStatus::kSuccess;
+}
+
+DlStatus DoorLockStorage::SetWeekdaySchedule(uint8_t scheduleIndex, uint16_t userIndex, DlScheduleStatus status,
+                                             DaysMaskMap daysMask, uint8_t startHour, uint8_t startMinute,
+                                             uint8_t endHour, uint8_t endMinute)
+{
+    VerifyOrReturnValue(mInitialized && scheduleIndex > 0 && userIndex > 0 &&
+                        scheduleIndex <= mLimits.numberOfWeekdaySchedulesPerUser &&
+                        userIndex <= mLimits.numberOfUsers,
+                        DlStatus::kFailure);
+    char key[PersistentStorageDelegate::kKeyLengthMax + 1];
+    VerifyOrReturnValue(MakeScheduleKey("ws", scheduleIndex, userIndex, key, sizeof(key)), DlStatus::kFailure);
+    auto  &record = mWeekdaySchedules[userIndex - 1][scheduleIndex - 1];
+    if (status == DlScheduleStatus::kAvailable) {
+        VerifyOrReturnValue(DeleteRecord(key) == CHIP_NO_ERROR, DlStatus::kFailure);
+        record = {};
+        return DlStatus::kSuccess;
+    }
+    record.status = status;
+    record.schedule = { daysMask, startHour, startMinute, endHour, endMinute };
+    VerifyOrReturnValue(WriteRecord(key, &record, sizeof(record)) == CHIP_NO_ERROR, DlStatus::kFailure);
+    return DlStatus::kSuccess;
+}
+
+DlStatus DoorLockStorage::GetYeardaySchedule(uint8_t scheduleIndex, uint16_t userIndex,
+                                             EmberAfPluginDoorLockYearDaySchedule  &schedule) const
+{
+    VerifyOrReturnValue(mInitialized && scheduleIndex > 0 && userIndex > 0 &&
+                        scheduleIndex <= mLimits.numberOfYeardaySchedulesPerUser &&
+                        userIndex <= mLimits.numberOfUsers,
+                        DlStatus::kFailure);
+    const auto  &record = mYeardaySchedules[userIndex - 1][scheduleIndex - 1];
+    VerifyOrReturnValue(record.status != DlScheduleStatus::kAvailable, DlStatus::kNotFound);
+    schedule = record.schedule;
+    return DlStatus::kSuccess;
+}
+
+DlStatus DoorLockStorage::SetYeardaySchedule(uint8_t scheduleIndex, uint16_t userIndex, DlScheduleStatus status,
+                                             uint32_t localStartTime, uint32_t localEndTime)
+{
+    VerifyOrReturnValue(mInitialized && scheduleIndex > 0 && userIndex > 0 &&
+                        scheduleIndex <= mLimits.numberOfYeardaySchedulesPerUser &&
+                        userIndex <= mLimits.numberOfUsers,
+                        DlStatus::kFailure);
+    char key[PersistentStorageDelegate::kKeyLengthMax + 1];
+    VerifyOrReturnValue(MakeScheduleKey("ys", scheduleIndex, userIndex, key, sizeof(key)), DlStatus::kFailure);
+    auto  &record = mYeardaySchedules[userIndex - 1][scheduleIndex - 1];
+    if (status == DlScheduleStatus::kAvailable) {
+        VerifyOrReturnValue(DeleteRecord(key) == CHIP_NO_ERROR, DlStatus::kFailure);
+        record = {};
+        return DlStatus::kSuccess;
+    }
+    record.status = status;
+    record.schedule = { localStartTime, localEndTime };
+    VerifyOrReturnValue(WriteRecord(key, &record, sizeof(record)) == CHIP_NO_ERROR, DlStatus::kFailure);
+    return DlStatus::kSuccess;
+}
+
+DlStatus DoorLockStorage::GetHolidaySchedule(uint8_t scheduleIndex,
+                                             EmberAfPluginDoorLockHolidaySchedule  &schedule) const
+{
+    VerifyOrReturnValue(mInitialized && scheduleIndex > 0 && scheduleIndex <= mLimits.numberOfHolidaySchedules,
+                        DlStatus::kFailure);
+    const auto  &record = mHolidaySchedules[scheduleIndex - 1];
+    VerifyOrReturnValue(record.status != DlScheduleStatus::kAvailable, DlStatus::kNotFound);
+    schedule = record.schedule;
+    return DlStatus::kSuccess;
+}
+
+DlStatus DoorLockStorage::SetHolidaySchedule(uint8_t scheduleIndex, DlScheduleStatus status,
+                                             uint32_t localStartTime, uint32_t localEndTime,
+                                             OperatingModeEnum operatingMode)
+{
+    VerifyOrReturnValue(mInitialized && scheduleIndex > 0 && scheduleIndex <= mLimits.numberOfHolidaySchedules,
+                        DlStatus::kFailure);
+    char key[PersistentStorageDelegate::kKeyLengthMax + 1];
+    VerifyOrReturnValue(MakeScheduleKey("hs", scheduleIndex, 0, key, sizeof(key)), DlStatus::kFailure);
+    auto  &record = mHolidaySchedules[scheduleIndex - 1];
+    if (status == DlScheduleStatus::kAvailable) {
+        VerifyOrReturnValue(DeleteRecord(key) == CHIP_NO_ERROR, DlStatus::kFailure);
+        record = {};
+        return DlStatus::kSuccess;
+    }
+    record.status = status;
+    record.schedule = { localStartTime, localEndTime, operatingMode };
+    VerifyOrReturnValue(WriteRecord(key, &record, sizeof(record)) == CHIP_NO_ERROR, DlStatus::kFailure);
+    return DlStatus::kSuccess;
+}
+
 bool DoorLockStorage::ValidatePIN(const ByteSpan  &pin, PinMatch  &match) const
 {
     VerifyOrReturnValue(mInitialized, false);
@@ -453,6 +587,14 @@ bool DoorLockStorage::MakeCredentialKey(CredentialTypeEnum type, uint16_t creden
                                         char * key, size_t keySize) const
 {
     return FormatKey(key, keySize, "dl/c/%u/%u", to_underlying(type), credentialIndex);
+}
+
+bool DoorLockStorage::MakeScheduleKey(const char * type, uint8_t scheduleIndex, uint16_t userIndex,
+                                      char * key, size_t keySize) const
+{
+    int length = snprintf(key, keySize, "dl/%s/%u/%u", type, scheduleIndex, userIndex);
+    return length > 0 && static_cast<size_t>(length) < keySize &&
+           static_cast<size_t>(length) <= PersistentStorageDelegate::kKeyLengthMax;
 }
 
 bool DoorLockStorage::IsValidUserRecord(const UserRecord  &user) const

--- a/examples/door_lock/main/lock/door_lock_storage.h
+++ b/examples/door_lock/main/lock/door_lock_storage.h
@@ -23,6 +23,9 @@ public:
     struct Limits {
         uint16_t numberOfUsers = 0;
         uint8_t numberOfCredentialsPerUser = 0;
+        uint8_t numberOfWeekdaySchedulesPerUser = 0;
+        uint8_t numberOfYeardaySchedulesPerUser = 0;
+        uint8_t numberOfHolidaySchedules = 0;
         uint16_t credentialSlotsByType[kCredentialTypeCount] = {};
     };
 
@@ -36,6 +39,8 @@ public:
     static constexpr uint8_t kMaxCredentialsPerUser = DoorLockCapabilities::kCredentialsPerUser;
     static constexpr uint16_t kMaxCredentialSlotsPerType = DoorLockCapabilities::kCredentialSlotsPerType;
     static constexpr uint8_t kMaxCredentialSize = 65;
+    static constexpr uint8_t kMaxSchedulesPerUser = 10;
+    static constexpr uint8_t kMaxHolidaySchedules = 10;
     static constexpr size_t kCredentialSlotCount = kCredentialTypeCount * kMaxCredentialSlotsPerType;
 
     static DoorLockStorage  &Instance()
@@ -57,6 +62,19 @@ public:
     bool SetCredential(uint16_t credentialIndex, chip::FabricIndex creator,
                        chip::FabricIndex modifier, DlCredentialStatus credentialStatus,
                        CredentialTypeEnum credentialType, const chip::ByteSpan  &credentialData);
+    DlStatus GetWeekdaySchedule(uint8_t scheduleIndex, uint16_t userIndex,
+                                EmberAfPluginDoorLockWeekDaySchedule  &schedule) const;
+    DlStatus SetWeekdaySchedule(uint8_t scheduleIndex, uint16_t userIndex, DlScheduleStatus status,
+                                DaysMaskMap daysMask, uint8_t startHour, uint8_t startMinute,
+                                uint8_t endHour, uint8_t endMinute);
+    DlStatus GetYeardaySchedule(uint8_t scheduleIndex, uint16_t userIndex,
+                                EmberAfPluginDoorLockYearDaySchedule  &schedule) const;
+    DlStatus SetYeardaySchedule(uint8_t scheduleIndex, uint16_t userIndex, DlScheduleStatus status,
+                                uint32_t localStartTime, uint32_t localEndTime);
+    DlStatus GetHolidaySchedule(uint8_t scheduleIndex, EmberAfPluginDoorLockHolidaySchedule  &schedule) const;
+    DlStatus SetHolidaySchedule(uint8_t scheduleIndex, DlScheduleStatus status,
+                                uint32_t localStartTime, uint32_t localEndTime,
+                                OperatingModeEnum operatingMode);
 
     struct PinMatch {
         uint16_t userIndex = 0;
@@ -105,6 +123,12 @@ private:
         uint8_t data[kMaxCredentialSize] = {};
     };
 
+    template <class Schedule>
+    struct ScheduleRecord {
+        DlScheduleStatus status = DlScheduleStatus::kAvailable;
+        Schedule schedule = {};
+    };
+
     CHIP_ERROR LoadMetadata();
     CHIP_ERROR LoadRecords();
     CHIP_ERROR RepairRelationships();
@@ -116,6 +140,8 @@ private:
     bool MakeUserKey(uint16_t userIndex, char * key, size_t keySize) const;
     bool MakeCredentialKey(CredentialTypeEnum type, uint16_t credentialIndex,
                            char * key, size_t keySize) const;
+    bool MakeScheduleKey(const char * type, uint8_t scheduleIndex, uint16_t userIndex,
+                         char * key, size_t keySize) const;
 
     bool IsValidUserRecord(const UserRecord  &user) const;
     bool IsValidCredentialRecord(const CredentialRecord  &credential,
@@ -131,5 +157,8 @@ private:
     UserRecord mUsers[kMaxUsers] = {};
     CredentialRecord mCredentials[kCredentialSlotCount] = {};
     CredentialStruct mUserCredentialViews[kMaxUsers][kMaxCredentialsPerUser] = {};
+    ScheduleRecord<EmberAfPluginDoorLockWeekDaySchedule> mWeekdaySchedules[kMaxUsers][kMaxSchedulesPerUser] = {};
+    ScheduleRecord<EmberAfPluginDoorLockYearDaySchedule> mYeardaySchedules[kMaxUsers][kMaxSchedulesPerUser] = {};
+    ScheduleRecord<EmberAfPluginDoorLockHolidaySchedule> mHolidaySchedules[kMaxHolidaySchedules] = {};
     bool mInitialized = false;
 };


### PR DESCRIPTION
## Description

Enable the Week Day, Year Day, and Holiday access-schedule features in the Door Lock example. The example publishes the schedule support counts and routes the schedule callbacks to `DoorLockStorage`, which persists schedule records.

The Week Day schedule count remains at the SDK default of one per user until #1828 adds its feature configuration.

The schedules are deliberately not enforced during PIN credential validation yet. This limitation is documented in the example README and should be addressed separately.

## Related

Fixes #1829
Related: #1828

## Testing

- `git diff --check`
- VS Code C++ diagnostics: no errors in the modified source files.
- The pre-commit CI job identified AStyle formatting changes in `door_lock_callbacks.cpp` and `door_lock_storage.cpp`; the formatting will be applied before the branch is squashed and republished.
- `idf.py -C examples/door_lock build` could not be run because ESP-IDF is not installed or loaded in this development container.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean - commits are squashed to the minimum necessary.