### PR TITLE
Enable door lock time synchronization

### DIFF
--- a/examples/door_lock/README.md
+++ b/examples/door_lock/README.md
@@ -12,7 +12,11 @@ No additional setup is required.
 
 No additional setup is required.
 
-## 3. Aliro over NFC Feature
+## 3. Time Synchronization
+
+The example enables SNTP-backed Time Synchronization and exposes the Time Zone feature on the Root Node.
+
+## 4. Aliro over NFC Feature
 
 ### Hardware Required
 
@@ -39,7 +43,7 @@ After commissioning with the Apple Home app, the Home app automatically adds a k
 | :----------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------: |
 | <img src="./img/home_key_add.jpeg" alt="Home Key added to Apple Wallet" width="300"> | <img src="./img/unlock_page.jpeg" alt="Unlocking the door with Apple Home" width="300"> |
 
-## 4. Local Controls and Status
+## 5. Local Controls and Status
 
 Press the boot button (front button on M5Stack Nano) to toggle the lock state. The RGB LED indicates the current state:
 
@@ -48,7 +52,7 @@ Press the boot button (front button on M5Stack Nano) to toggle the lock state. T
 - Amber: locking or unlocking
 - Off: unknown state
 
-## 5. Diagnostic Console
+## 6. Diagnostic Console
 
 The door-lock debug command is available under `matter esp dl`:
 

--- a/examples/door_lock/main/app_main.cpp
+++ b/examples/door_lock/main/app_main.cpp
@@ -29,6 +29,9 @@
 
 #include <app/server/CommissioningWindowManager.h>
 #include <app/server/Server.h>
+#if CONFIG_ENABLE_SNTP_TIME_SYNC
+#include <app/clusters/time-synchronization-server/DefaultTimeSyncDelegate.h>
+#endif
 #ifdef CONFIG_ENABLE_ALIRO_OVER_NFC
 #include <aliro_door_lock_delegate.h>
 #endif
@@ -156,6 +159,21 @@ extern "C" void app_main()
     // node handle can be used to add/modify other endpoints.
     node_t *node = node::create(&node_config, nullptr, app_identification_cb);
     ABORT_APP_ON_FAILURE(node != nullptr, ESP_LOGE(TAG, "Failed to create Matter node"));
+
+#if CONFIG_ENABLE_SNTP_TIME_SYNC
+    endpoint_t *root_node_endpoint = endpoint::get_first(node);
+    ABORT_APP_ON_FAILURE(root_node_endpoint != nullptr, ESP_LOGE(TAG, "Failed to find root node endpoint"));
+
+    cluster::time_synchronization::config_t time_sync_config;
+    static chip::app::Clusters::TimeSynchronization::DefaultTimeSyncDelegate time_sync_delegate;
+    time_sync_config.delegate = &time_sync_delegate;
+    cluster_t *time_sync_cluster =
+        cluster::time_synchronization::create(root_node_endpoint, &time_sync_config, CLUSTER_FLAG_SERVER);
+    ABORT_APP_ON_FAILURE(time_sync_cluster != nullptr, ESP_LOGE(TAG, "Failed to create time synchronization cluster"));
+
+    cluster::time_synchronization::feature::time_zone::config_t time_zone_config;
+    cluster::time_synchronization::feature::time_zone::add(time_sync_cluster, &time_zone_config);
+#endif
 
     door_lock::config_t door_lock_config;
 #ifdef CONFIG_ENABLE_ALIRO_OVER_NFC

--- a/examples/door_lock/sdkconfig.defaults
+++ b/examples/door_lock/sdkconfig.defaults
@@ -18,6 +18,9 @@ CONFIG_PARTITION_TABLE_OFFSET=0xC000
 # Enable chip shell
 CONFIG_ENABLE_CHIP_SHELL=y
 
+# Enable SNTP-backed Time Synchronization for access schedule evaluation.
+CONFIG_ENABLE_SNTP_TIME_SYNC=y
+
 # This example only use 2 dynamic endpoints
 CONFIG_ESP_MATTER_MAX_DYNAMIC_ENDPOINT_COUNT=2
 


### PR DESCRIPTION
## Description

Enable SNTP-backed Time Synchronization for the Door Lock example. The Root Node now creates a Time Synchronization server with `DefaultTimeSyncDelegate` and exposes the Time Zone feature.

This is a prerequisite for a future access-schedule enforcement change, which needs reliable local time. It does not change PIN validation or schedule enforcement.

## Related

Related: #1829

## Testing

- `git diff --check`
- Pre-commit hooks passed: AStyle, keep-sorted, and codespell.
- VS Code C++ diagnostics: no errors in the modified C++ file.
- `idf.py -C examples/door_lock build` could not be run because ESP-IDF is not installed or loaded in this development container.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean - commits are squashed to the minimum necessary.