### PR TITLE
door_lock: align status LED color with locked=green/unlocked=red convention

### DIFF
--- a/examples/door_lock/README.md
+++ b/examples/door_lock/README.md
@@ -43,8 +43,8 @@ After commissioning with the Apple Home app, the Home app automatically adds a k
 
 Press the boot button (front button on M5Stack Nano) to toggle the lock state. The RGB LED indicates the current state:
 
-- Red: locked
-- Green: unlocked or unlatched
+- Green: locked
+- Red: unlocked or unlatched
 - Amber: locking or unlocking
 - Off: unknown state
 

--- a/examples/door_lock/main/app_driver.cpp
+++ b/examples/door_lock/main/app_driver.cpp
@@ -147,10 +147,12 @@ static esp_err_t app_driver_status_led_set(BoltLockManager::State state)
     uint32_t color = SET_IRGB(0, 0, 0, 0);
     switch (state) {
     case BoltLockManager::State::kLockingCompleted:
-        color = SET_IRGB(0, kStatusLedLevel, 0, 0);
+        // Green indicates the secure (locked) state, matching common smart-lock conventions.
+        color = SET_IRGB(0, 0, kStatusLedLevel, 0);
         break;
     case BoltLockManager::State::kUnlockingCompleted:
-        color = SET_IRGB(0, 0, kStatusLedLevel, 0);
+        // Red indicates the attention-needed (unlocked) state.
+        color = SET_IRGB(0, kStatusLedLevel, 0, 0);
         break;
     case BoltLockManager::State::kLockingInitiated:
     case BoltLockManager::State::kUnlockingInitiated:


### PR DESCRIPTION
## Summary
Swaps the RGB status LED mapping in the `door_lock` example so it matches the convention used by common smart-lock manufacturers (Nuki, August, Aqara): green signals the secure/locked state and red signals the unlocked/attention-needed state.

- `kLockingCompleted` → green (was red)
- `kUnlockingCompleted` → red (was green)
- Amber (locking/unlocking transition) and off (unknown state) are unchanged
- README updated to match

Fixes #1839

## Test plan
- [x] Build for ESP32-C6 / ESP32-H2 and confirm LED colors on lock/unlock

